### PR TITLE
Feature/htf 3tier correlation

### DIFF
--- a/.kiro/specs/agentictrader-platform/SPEC_UPDATE_3TIER_HTF.md
+++ b/.kiro/specs/agentictrader-platform/SPEC_UPDATE_3TIER_HTF.md
@@ -1,0 +1,144 @@
+# Spec Update: 3-Tier HTF Timeframe Correlation (TTrades Methodology)
+
+**Date**: 2026-05-02  
+**Status**: Spec Updated, Task 9 Ready for Re-implementation
+
+---
+
+## Summary
+
+Updated the AgentICTrader.AI spec to reflect the **3-tier timeframe correlation structure** based on TTrades Fractal Model methodology, replacing the simple single-level HTF mappings.
+
+---
+
+## Changes Made
+
+### 1. Requirements.md (FR-2)
+
+**Before**: Simple single-level mappings (M1→M5, M5→M15, etc.)
+
+**After**: Comprehensive 3-tier structure with:
+
+#### FR-2.1: 3-Tier Timeframe Correlation
+- **Higher TF (Bias Layer)**: Determines market direction via Candle 2 closures and Candle 3 expansions
+- **Mid TF (Structure Layer)**: Confirms alignment via CISD or market structure shift
+- **Lower TF (Entry Layer)**: Precision timing for entry
+
+**Trading Style-Specific Correlations:**
+
+| Trading Style | Higher TF (Bias) | Mid TF (Structure) | Lower TF (Entry) |
+|---------------|------------------|-------------------|------------------|
+| Scalping      | H1               | M15               | M1               |
+| Intraday Standard | D1          | H1                | M5               |
+| Intraday Simple | D1            | H4                | M15              |
+| Swing Trading | W1               | D1                | H1 or H4         |
+| Position/Crypto | MN1            | W1                | H4               |
+
+**Supported Timeframes**: M1, M3, M5, M15, M30, H1, H4, D1, W1, MN1
+
+#### FR-2.2: Candle Numbering System (TTFM)
+- Candle 1 (Setup): Establishes range
+- Candle 2 (Reversal/Manipulation): Sweep + closure inside range
+  - Small wick → trade Candle 2 expansion
+  - Large wick → wait for Candle 3
+- Candle 3 (Expansion/Distribution): Aggressive move to liquidity target
+
+#### FR-2.3: Change in State of Delivery (CISD)
+- Bullish CISD: Sweep low, close above last down-close open
+- Bearish CISD: Sweep high, close below last up-close open
+- Must occur inside Higher TF Candle 2/3 structure
+
+#### FR-2.4: HTF Projection Levels
+- HTF Open (bias anchor), HTF High (upper boundary), HTF Low (lower boundary)
+- Compute price position, range proximity percentages
+- Store in TimescaleDB indicators table
+
+#### FR-2.5: Expansion Sync Principle
+- All three timeframes must expand in same direction for highest probability
+- "Wick Concept": wait for wrong direction first, then enter on body expansion
+
+### 2. Requirements.md (FR-1)
+
+**Updated timeframes**: M1, M3, M5, M15, M30, H1, H4, D1, W1, MN1 (added M3, M30, MN1)
+
+### 3. Design.md
+
+**Updated** "Sole Technical Indicator" section to include:
+- 3-tier structure explanation
+- Trading style correlations table
+- Candle Numbering System (TTFM)
+- CISD definition
+
+### 4. Tasks.md (Task 9)
+
+**Before**: Simple single-level HTF selector with `get_htf_timeframe()` and `get_htf_timeframes()`
+
+**After**: 3-tier correlation system with:
+
+**Functions to implement:**
+- `get_htf_correlation(current_tf: str, trading_style: TradingStyle) -> tuple[str, str, str]`
+- `get_bias_timeframe(current_tf: str, trading_style: TradingStyle) -> str`
+- `get_structure_timeframe(current_tf: str, trading_style: TradingStyle) -> str`
+- `get_entry_timeframe(current_tf: str, trading_style: TradingStyle) -> str`
+- `TradingStyle` enum: SCALPING, INTRADAY_STANDARD, INTRADAY_SIMPLE, SWING, POSITION
+- `SUPPORTED_TIMEFRAMES` constant
+
+**Test requirements:**
+- All trading style correlations return correct 3-tier tuples
+- Individual layer extraction functions work correctly
+- All timeframes supported: M1, M3, M5, M15, M30, H1, H4, D1, W1, MN1
+- Invalid inputs raise ValueError
+- Property test: strict timeframe hierarchy (bias > structure > entry)
+
+---
+
+## Next Steps
+
+1. **Delete old implementation**:
+   - `ml/features/htf_selector.py` (old version)
+   - `backend/tests/test_htf_selector.py` (old version)
+
+2. **Re-implement Task 9** following the updated spec:
+   - Write new failing tests based on 3-tier requirements
+   - Implement 3-tier correlation logic
+   - Verify all tests pass
+
+3. **Update dependent tasks** (if any reference the old API):
+   - Task 10: HTF OHLC computation
+   - Task 14: Feature pipeline orchestration
+
+---
+
+## Key Concepts from TTrades Methodology
+
+### The 3-Question Framework
+Every trade reasoning must answer:
+1. **Where has price come from?** (HTF context, previous session range, PD arrays)
+2. **Where is it now?** (current time window phase, price vs reference opens)
+3. **Where is it likely to go?** (nearest liquidity pool or imbalance to rebalance)
+
+### Entry Bias Rules
+- **Bullish setup**: Prefer entries BELOW session/candle open (manipulation wick down first, then expansion up)
+- **Bearish setup**: Prefer entries ABOVE session/candle open (manipulation wick up first, then expansion down)
+
+### Expansion Sync
+Highest probability trades occur when Daily, Hourly, and 5-minute charts are ALL expanding in the same direction.
+
+### The Wick Concept
+On every timeframe, wait for price to trade in the "wrong" direction first (forming the wick) before it reverses into the "true" move (the body expansion).
+
+---
+
+## Files Modified
+
+1. `.kiro/specs/agentictrader-platform/requirements.md` - FR-1, FR-2 completely rewritten
+2. `.kiro/specs/agentictrader-platform/design.md` - HTF section updated
+3. `.kiro/specs/agentictrader-platform/tasks.md` - Task 9 rewritten
+
+---
+
+## Implementation Status
+
+- [x] Spec updated with 3-tier methodology
+- [ ] Old Task 9 implementation needs to be replaced
+- [ ] New Task 9 implementation (3-tier) - **READY TO START**

--- a/.kiro/specs/agentictrader-platform/tasks.md
+++ b/.kiro/specs/agentictrader-platform/tasks.md
@@ -107,7 +107,7 @@
   - Validate loaded data: no gaps > 2x timeframe duration on trading days, no OHLC violations
   - Log summary: instrument, timeframe, row count, date range, gap count
 
-- [-] 8. Implement economic calendar ingestion
+- [x] 8. Implement economic calendar ingestion
   - **8a. RED — Write failing tests** (`backend/tests/test_calendar_ingestion.py`)
     - Test: events ingested for currencies USD, EUR, GBP, XAU
     - Test: events stored in TimescaleDB economic_events table with correct schema

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,7 +8,11 @@ import pytest
 from django.conf import settings
 
 # Get the absolute path to the project root
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+# Add project root to sys.path so we can import services module
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
 
 def pytest_configure():
     """Configure Django for testing."""

--- a/backend/tests/test_calendar_ingestion.py
+++ b/backend/tests/test_calendar_ingestion.py
@@ -24,6 +24,26 @@ from services.market_data.calendar_ingestion import (
 )
 
 
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+def create_mock_pool():
+    """Create a properly mocked asyncpg pool for testing."""
+    mock_pool = MagicMock()
+    mock_conn = AsyncMock()
+    
+    # Create an async context manager for acquire()
+    async_context = AsyncMock()
+    async_context.__aenter__ = AsyncMock(return_value=mock_conn)
+    async_context.__aexit__ = AsyncMock(return_value=None)
+    
+    mock_pool.acquire = MagicMock(return_value=async_context)
+    mock_pool.close = AsyncMock()
+    
+    return mock_pool, mock_conn
+
+
 # ===========================================================================
 # 1. Test: events ingested for currencies USD, EUR, GBP, XAU
 # ===========================================================================
@@ -123,24 +143,23 @@ async def test_events_stored_with_correct_schema():
         db_password="changeme",
     )
     
-    await ingestion.connect()
-    
-    event = EconomicEvent(
-        event_time=datetime(2026, 5, 1, 8, 30, 0, tzinfo=timezone.utc),
-        currency="USD",
-        event_name="Non-Farm Payrolls",
-        impact="HIGH",
-        forecast="200K",
-        previous="180K",
-        actual="210K",
-        source="test",
-    )
-    
     # Mock the database connection
-    with patch.object(ingestion, "_pool") as mock_pool:
-        mock_conn = AsyncMock()
-        mock_pool.acquire.return_value.__aenter__.return_value = mock_conn
-        mock_conn.execute = AsyncMock()
+    with patch("services.market_data.calendar_ingestion.asyncpg.create_pool", new_callable=AsyncMock) as mock_create_pool:
+        mock_pool, mock_conn = create_mock_pool()
+        mock_create_pool.return_value = mock_pool
+        
+        await ingestion.connect()
+        
+        event = EconomicEvent(
+            event_time=datetime(2026, 5, 1, 8, 30, 0, tzinfo=timezone.utc),
+            currency="USD",
+            event_name="Non-Farm Payrolls",
+            impact="HIGH",
+            forecast="200K",
+            previous="180K",
+            actual="210K",
+            source="test",
+        )
         
         await ingestion._store_event(event)
         
@@ -164,8 +183,8 @@ async def test_events_stored_with_correct_schema():
         assert event.currency in call_args[0]
         assert event.event_name in call_args[0]
         assert event.impact in call_args[0]
-    
-    await ingestion.close()
+        
+        await ingestion.close()
 
 
 @pytest.mark.asyncio
@@ -219,38 +238,45 @@ async def test_daily_refresh_scheduled_at_0005_utc():
         db_password="changeme",
     )
     
-    await ingestion.connect()
-    
-    # Start the scheduler
-    ingestion.start_scheduler()
-    
-    # Verify scheduler is running
-    assert ingestion._scheduler is not None, "Scheduler must be initialized"
-    assert ingestion._scheduler.running, "Scheduler must be running"
-    
-    # Verify job is scheduled
-    jobs = ingestion._scheduler.get_jobs()
-    assert len(jobs) > 0, "At least one job must be scheduled"
-    
-    # Find the daily refresh job
-    refresh_job = None
-    for job in jobs:
-        if "refresh" in job.id.lower() or "ingest" in job.id.lower():
-            refresh_job = job
-            break
-    
-    assert refresh_job is not None, "Daily refresh job must be scheduled"
-    
-    # Verify job runs at 00:05 UTC
-    trigger = refresh_job.trigger
-    assert hasattr(trigger, "hour"), "Job must have hour trigger"
-    assert hasattr(trigger, "minute"), "Job must have minute trigger"
-    assert trigger.hour == 0, "Job must run at hour 0 (midnight)"
-    assert trigger.minute == 5, "Job must run at minute 5"
-    
-    # Stop the scheduler
-    ingestion.stop_scheduler()
-    await ingestion.close()
+    # Mock the database connection
+    with patch("services.market_data.calendar_ingestion.asyncpg.create_pool", new_callable=AsyncMock) as mock_create_pool:
+        mock_pool = AsyncMock()
+        mock_create_pool.return_value = mock_pool
+        
+        await ingestion.connect()
+        
+        # Start the scheduler
+        ingestion.start_scheduler()
+        
+        # Verify scheduler is running
+        assert ingestion._scheduler is not None, "Scheduler must be initialized"
+        assert ingestion._scheduler.running, "Scheduler must be running"
+        
+        # Verify job is scheduled
+        jobs = ingestion._scheduler.get_jobs()
+        assert len(jobs) > 0, "At least one job must be scheduled"
+        
+        # Find the daily refresh job
+        refresh_job = None
+        for job in jobs:
+            if "refresh" in job.id.lower() or "ingest" in job.id.lower():
+                refresh_job = job
+                break
+        
+        assert refresh_job is not None, "Daily refresh job must be scheduled"
+        
+        # Verify job runs at 00:05 UTC
+        trigger = refresh_job.trigger
+        # CronTrigger stores fields in a different way
+        trigger_str = str(trigger)
+        assert "hour='0'" in trigger_str or "hour=0" in trigger_str, "Job must run at hour 0 (midnight)"
+        assert "minute='5'" in trigger_str or "minute=5" in trigger_str, "Job must run at minute 5"
+        # Timezone is set but may not appear in string representation, check the trigger object
+        assert trigger.timezone is not None, "Job must have a timezone set"
+        
+        # Stop the scheduler
+        ingestion.stop_scheduler()
+        await ingestion.close()
 
 
 @pytest.mark.asyncio
@@ -266,16 +292,24 @@ async def test_scheduler_can_be_stopped():
         db_password="changeme",
     )
     
-    await ingestion.connect()
-    ingestion.start_scheduler()
-    
-    assert ingestion._scheduler.running, "Scheduler must be running"
-    
-    ingestion.stop_scheduler()
-    
-    assert not ingestion._scheduler.running, "Scheduler must be stopped"
-    
-    await ingestion.close()
+    # Mock the database connection
+    with patch("services.market_data.calendar_ingestion.asyncpg.create_pool", new_callable=AsyncMock) as mock_create_pool:
+        mock_pool = AsyncMock()
+        mock_create_pool.return_value = mock_pool
+        
+        await ingestion.connect()
+        ingestion.start_scheduler()
+        
+        assert ingestion._scheduler.running, "Scheduler must be running"
+        
+        ingestion.stop_scheduler()
+        
+        # Give the scheduler a moment to shut down
+        await asyncio.sleep(0.1)
+        
+        assert not ingestion._scheduler.running, "Scheduler must be stopped"
+        
+        await ingestion.close()
 
 
 # ===========================================================================
@@ -296,26 +330,25 @@ async def test_duplicate_events_not_inserted_twice():
         db_password="changeme",
     )
     
-    await ingestion.connect()
-    
-    event = EconomicEvent(
-        event_time=datetime(2026, 5, 1, 8, 30, 0, tzinfo=timezone.utc),
-        currency="USD",
-        event_name="Non-Farm Payrolls",
-        impact="HIGH",
-        forecast="200K",
-        previous="180K",
-        actual=None,
-        source="test",
-    )
-    
     # Mock the database connection
-    with patch.object(ingestion, "_pool") as mock_pool:
-        mock_conn = AsyncMock()
-        mock_pool.acquire.return_value.__aenter__.return_value = mock_conn
+    with patch("services.market_data.calendar_ingestion.asyncpg.create_pool", new_callable=AsyncMock) as mock_create_pool:
+        mock_pool, mock_conn = create_mock_pool()
+        mock_create_pool.return_value = mock_pool
+        
+        await ingestion.connect()
+        
+        event = EconomicEvent(
+            event_time=datetime(2026, 5, 1, 8, 30, 0, tzinfo=timezone.utc),
+            currency="USD",
+            event_name="Non-Farm Payrolls",
+            impact="HIGH",
+            forecast="200K",
+            previous="180K",
+            actual=None,
+            source="test",
+        )
         
         # First insert should succeed
-        mock_conn.execute = AsyncMock()
         await ingestion._store_event(event)
         first_call_count = mock_conn.execute.call_count
         
@@ -329,8 +362,8 @@ async def test_duplicate_events_not_inserted_twice():
         # Should use ON CONFLICT DO NOTHING or similar deduplication
         assert "on conflict" in sql or "where not exists" in sql, \
             "SQL must handle duplicates with ON CONFLICT or WHERE NOT EXISTS"
-    
-    await ingestion.close()
+        
+        await ingestion.close()
 
 
 @pytest.mark.asyncio
@@ -346,47 +379,47 @@ async def test_duplicate_check_by_event_time_currency_name():
         db_password="changeme",
     )
     
-    await ingestion.connect()
-    
-    # Same event_time, currency, event_name = duplicate
-    event1 = EconomicEvent(
-        event_time=datetime(2026, 5, 1, 8, 30, 0, tzinfo=timezone.utc),
-        currency="USD",
-        event_name="Non-Farm Payrolls",
-        impact="HIGH",
-        forecast="200K",
-        previous="180K",
-        actual=None,
-        source="test",
-    )
-    
-    event2 = EconomicEvent(
-        event_time=datetime(2026, 5, 1, 8, 30, 0, tzinfo=timezone.utc),
-        currency="USD",
-        event_name="Non-Farm Payrolls",
-        impact="HIGH",
-        forecast="210K",  # Different forecast, but same key fields
-        previous="180K",
-        actual=None,
-        source="test",
-    )
-    
-    # Different event_time = not duplicate
-    event3 = EconomicEvent(
-        event_time=datetime(2026, 5, 1, 9, 30, 0, tzinfo=timezone.utc),  # Different time
-        currency="USD",
-        event_name="Non-Farm Payrolls",
-        impact="HIGH",
-        forecast="200K",
-        previous="180K",
-        actual=None,
-        source="test",
-    )
-    
-    with patch.object(ingestion, "_pool") as mock_pool:
-        mock_conn = AsyncMock()
-        mock_pool.acquire.return_value.__aenter__.return_value = mock_conn
-        mock_conn.execute = AsyncMock()
+    # Mock the database connection
+    with patch("services.market_data.calendar_ingestion.asyncpg.create_pool", new_callable=AsyncMock) as mock_create_pool:
+        mock_pool, mock_conn = create_mock_pool()
+        mock_create_pool.return_value = mock_pool
+        
+        await ingestion.connect()
+        
+        # Same event_time, currency, event_name = duplicate
+        event1 = EconomicEvent(
+            event_time=datetime(2026, 5, 1, 8, 30, 0, tzinfo=timezone.utc),
+            currency="USD",
+            event_name="Non-Farm Payrolls",
+            impact="HIGH",
+            forecast="200K",
+            previous="180K",
+            actual=None,
+            source="test",
+        )
+        
+        event2 = EconomicEvent(
+            event_time=datetime(2026, 5, 1, 8, 30, 0, tzinfo=timezone.utc),
+            currency="USD",
+            event_name="Non-Farm Payrolls",
+            impact="HIGH",
+            forecast="210K",  # Different forecast, but same key fields
+            previous="180K",
+            actual=None,
+            source="test",
+        )
+        
+        # Different event_time = not duplicate
+        event3 = EconomicEvent(
+            event_time=datetime(2026, 5, 1, 9, 30, 0, tzinfo=timezone.utc),  # Different time
+            currency="USD",
+            event_name="Non-Farm Payrolls",
+            impact="HIGH",
+            forecast="200K",
+            previous="180K",
+            actual=None,
+            source="test",
+        )
         
         await ingestion._store_event(event1)
         await ingestion._store_event(event2)  # Should be treated as duplicate
@@ -401,8 +434,8 @@ async def test_duplicate_check_by_event_time_currency_name():
             assert "event_time" in sql
             assert "currency" in sql
             assert "event_name" in sql
-    
-    await ingestion.close()
+        
+        await ingestion.close()
 
 
 # ===========================================================================
@@ -520,39 +553,44 @@ async def test_ingest_events_stores_all_fetched_events():
         db_password="changeme",
     )
     
-    await ingestion.connect()
-    
-    mock_events = [
-        EconomicEvent(
-            event_time=datetime.now(timezone.utc),
-            currency="USD",
-            event_name="Event 1",
-            impact="HIGH",
-            forecast=None,
-            previous=None,
-            actual=None,
-            source="test",
-        ),
-        EconomicEvent(
-            event_time=datetime.now(timezone.utc),
-            currency="EUR",
-            event_name="Event 2",
-            impact="MEDIUM",
-            forecast=None,
-            previous=None,
-            actual=None,
-            source="test",
-        ),
-    ]
-    
-    with patch.object(ingestion, "_fetch_events", return_value=mock_events):
-        with patch.object(ingestion, "_store_event", new_callable=AsyncMock) as mock_store:
-            await ingestion.ingest_events()
-            
-            # Verify _store_event was called for each event
-            assert mock_store.call_count == len(mock_events)
-    
-    await ingestion.close()
+    # Mock the database connection
+    with patch("services.market_data.calendar_ingestion.asyncpg.create_pool", new_callable=AsyncMock) as mock_create_pool:
+        mock_pool = AsyncMock()
+        mock_create_pool.return_value = mock_pool
+        
+        await ingestion.connect()
+        
+        mock_events = [
+            EconomicEvent(
+                event_time=datetime.now(timezone.utc),
+                currency="USD",
+                event_name="Event 1",
+                impact="HIGH",
+                forecast=None,
+                previous=None,
+                actual=None,
+                source="test",
+            ),
+            EconomicEvent(
+                event_time=datetime.now(timezone.utc),
+                currency="EUR",
+                event_name="Event 2",
+                impact="MEDIUM",
+                forecast=None,
+                previous=None,
+                actual=None,
+                source="test",
+            ),
+        ]
+        
+        with patch.object(ingestion, "_fetch_events", return_value=mock_events):
+            with patch.object(ingestion, "_store_event", new_callable=AsyncMock) as mock_store:
+                await ingestion.ingest_events()
+                
+                # Verify _store_event was called for each event
+                assert mock_store.call_count == len(mock_events)
+        
+        await ingestion.close()
 
 
 # ===========================================================================

--- a/backend/tests/test_htf_selector.py
+++ b/backend/tests/test_htf_selector.py
@@ -1,0 +1,239 @@
+"""
+Test suite for HTF 3-tier timeframe correlation logic (TTrades methodology).
+
+This module tests the 3-tier timeframe correlation system:
+- Higher TF (Bias Layer): Determines market direction
+- Mid TF (Structure Layer): Confirms alignment via CISD
+- Lower TF (Entry Layer): Precision timing for entry
+
+**Validates: Requirements FR-2.1**
+"""
+
+import os
+import sys
+
+import pytest
+from hypothesis import given, strategies as st
+
+# ---------------------------------------------------------------------------
+# Path setup — add workspace root so `ml` package is importable
+# ---------------------------------------------------------------------------
+_WORKSPACE_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _WORKSPACE_ROOT not in sys.path:
+    sys.path.insert(0, _WORKSPACE_ROOT)
+
+from ml.features.htf_selector import (  # noqa: E402
+    TradingStyle,
+    get_htf_correlation,
+    get_bias_timeframe,
+    get_structure_timeframe,
+    get_entry_timeframe,
+    SUPPORTED_TIMEFRAMES,
+)
+
+
+class TestTradingStyleCorrelations:
+    """Test that all trading styles return correct 3-tier tuples."""
+
+    def test_scalping_correlation(self):
+        """Scalping: H1 → M15 → M1"""
+        result = get_htf_correlation("M1", TradingStyle.SCALPING)
+        assert result == ("H1", "M15", "M1")
+
+    def test_intraday_standard_correlation(self):
+        """Intraday Standard: D1 → H1 → M5"""
+        result = get_htf_correlation("M5", TradingStyle.INTRADAY_STANDARD)
+        assert result == ("D1", "H1", "M5")
+
+    def test_intraday_simple_correlation(self):
+        """Intraday Simple: D1 → H4 → M15"""
+        result = get_htf_correlation("M15", TradingStyle.INTRADAY_SIMPLE)
+        assert result == ("D1", "H4", "M15")
+
+    def test_swing_correlation(self):
+        """Swing: W1 → D1 → H1 (or H4)"""
+        result = get_htf_correlation("H1", TradingStyle.SWING)
+        assert result == ("W1", "D1", "H1")
+
+    def test_position_correlation(self):
+        """Position/Crypto: MN1 → W1 → H4"""
+        result = get_htf_correlation("H4", TradingStyle.POSITION)
+        assert result == ("MN1", "W1", "H4")
+
+
+class TestIndividualLayerExtraction:
+    """Test individual layer extraction functions."""
+
+    def test_get_bias_timeframe_scalping(self):
+        """Bias timeframe for scalping should be H1."""
+        result = get_bias_timeframe("M1", TradingStyle.SCALPING)
+        assert result == "H1"
+
+    def test_get_structure_timeframe_scalping(self):
+        """Structure timeframe for scalping should be M15."""
+        result = get_structure_timeframe("M1", TradingStyle.SCALPING)
+        assert result == "M15"
+
+    def test_get_entry_timeframe_scalping(self):
+        """Entry timeframe for scalping should be M1."""
+        result = get_entry_timeframe("M1", TradingStyle.SCALPING)
+        assert result == "M1"
+
+    def test_get_bias_timeframe_intraday_standard(self):
+        """Bias timeframe for intraday standard should be D1."""
+        result = get_bias_timeframe("M5", TradingStyle.INTRADAY_STANDARD)
+        assert result == "D1"
+
+    def test_get_structure_timeframe_intraday_standard(self):
+        """Structure timeframe for intraday standard should be H1."""
+        result = get_structure_timeframe("M5", TradingStyle.INTRADAY_STANDARD)
+        assert result == "H1"
+
+    def test_get_entry_timeframe_intraday_standard(self):
+        """Entry timeframe for intraday standard should be M5."""
+        result = get_entry_timeframe("M5", TradingStyle.INTRADAY_STANDARD)
+        assert result == "M5"
+
+    def test_get_bias_timeframe_position(self):
+        """Bias timeframe for position should be MN1."""
+        result = get_bias_timeframe("H4", TradingStyle.POSITION)
+        assert result == "MN1"
+
+    def test_get_structure_timeframe_position(self):
+        """Structure timeframe for position should be W1."""
+        result = get_structure_timeframe("H4", TradingStyle.POSITION)
+        assert result == "W1"
+
+    def test_get_entry_timeframe_position(self):
+        """Entry timeframe for position should be H4."""
+        result = get_entry_timeframe("H4", TradingStyle.POSITION)
+        assert result == "H4"
+
+
+class TestSupportedTimeframes:
+    """Test all supported timeframes are recognized."""
+
+    def test_supported_timeframes_constant(self):
+        """All required timeframes should be in SUPPORTED_TIMEFRAMES."""
+        expected = {"M1", "M3", "M5", "M15", "M30", "H1", "H4", "D1", "W1", "MN1"}
+        assert SUPPORTED_TIMEFRAMES == expected
+
+    @pytest.mark.parametrize(
+        "timeframe",
+        ["M1", "M3", "M5", "M15", "M30", "H1", "H4", "D1", "W1", "MN1"],
+    )
+    def test_all_timeframes_supported(self, timeframe):
+        """Each timeframe should be in SUPPORTED_TIMEFRAMES."""
+        assert timeframe in SUPPORTED_TIMEFRAMES
+
+
+class TestInvalidInputs:
+    """Test that invalid inputs raise appropriate errors."""
+
+    def test_invalid_timeframe_raises_error(self):
+        """Invalid timeframe should raise ValueError."""
+        with pytest.raises(ValueError, match="Unsupported timeframe"):
+            get_htf_correlation("M2", TradingStyle.SCALPING)
+
+    def test_invalid_trading_style_raises_error(self):
+        """Invalid trading style should raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid trading_style"):
+            get_htf_correlation("M1", "INVALID_STYLE")
+
+    def test_none_timeframe_raises_error(self):
+        """None timeframe should raise ValueError."""
+        with pytest.raises(ValueError):
+            get_htf_correlation(None, TradingStyle.SCALPING)
+
+    def test_none_trading_style_raises_error(self):
+        """None trading style should raise ValueError."""
+        with pytest.raises(ValueError):
+            get_htf_correlation("M1", None)
+
+
+class TestTimeframeHierarchyProperty:
+    """Property-based test: bias_tf > structure_tf > entry_tf (strict hierarchy)."""
+
+    # Timeframe duration mapping in minutes
+    TIMEFRAME_MINUTES = {
+        "M1": 1,
+        "M3": 3,
+        "M5": 5,
+        "M15": 15,
+        "M30": 30,
+        "H1": 60,
+        "H4": 240,
+        "D1": 1440,
+        "W1": 10080,
+        "MN1": 43200,  # Approximate 30 days
+    }
+
+    @pytest.mark.parametrize(
+        "trading_style",
+        [
+            TradingStyle.SCALPING,
+            TradingStyle.INTRADAY_STANDARD,
+            TradingStyle.INTRADAY_SIMPLE,
+            TradingStyle.SWING,
+            TradingStyle.POSITION,
+        ],
+    )
+    def test_strict_timeframe_hierarchy(self, trading_style):
+        """
+        Property: bias_tf duration > structure_tf duration > entry_tf duration.
+        
+        **Validates: Requirements FR-2.1**
+        """
+        # Use a representative timeframe for each style
+        timeframe_map = {
+            TradingStyle.SCALPING: "M1",
+            TradingStyle.INTRADAY_STANDARD: "M5",
+            TradingStyle.INTRADAY_SIMPLE: "M15",
+            TradingStyle.SWING: "H1",
+            TradingStyle.POSITION: "H4",
+        }
+        
+        current_tf = timeframe_map[trading_style]
+        bias_tf, structure_tf, entry_tf = get_htf_correlation(current_tf, trading_style)
+        
+        bias_duration = self.TIMEFRAME_MINUTES[bias_tf]
+        structure_duration = self.TIMEFRAME_MINUTES[structure_tf]
+        entry_duration = self.TIMEFRAME_MINUTES[entry_tf]
+        
+        assert bias_duration > structure_duration, (
+            f"{trading_style.value}: Bias TF ({bias_tf}={bias_duration}min) "
+            f"must be > Structure TF ({structure_tf}={structure_duration}min)"
+        )
+        assert structure_duration > entry_duration, (
+            f"{trading_style.value}: Structure TF ({structure_tf}={structure_duration}min) "
+            f"must be > Entry TF ({entry_tf}={entry_duration}min)"
+        )
+
+
+class TestAllTradingStylesWithAllTimeframes:
+    """Comprehensive test: all trading styles work with their designated timeframes."""
+
+    @pytest.mark.parametrize(
+        "current_tf,trading_style,expected",
+        [
+            # Scalping
+            ("M1", TradingStyle.SCALPING, ("H1", "M15", "M1")),
+            ("M5", TradingStyle.SCALPING, ("H1", "M15", "M1")),
+            # Intraday Standard
+            ("M5", TradingStyle.INTRADAY_STANDARD, ("D1", "H1", "M5")),
+            ("M15", TradingStyle.INTRADAY_STANDARD, ("D1", "H1", "M5")),
+            # Intraday Simple
+            ("M15", TradingStyle.INTRADAY_SIMPLE, ("D1", "H4", "M15")),
+            ("M30", TradingStyle.INTRADAY_SIMPLE, ("D1", "H4", "M15")),
+            # Swing
+            ("H1", TradingStyle.SWING, ("W1", "D1", "H1")),
+            ("H4", TradingStyle.SWING, ("W1", "D1", "H1")),
+            # Position
+            ("H4", TradingStyle.POSITION, ("MN1", "W1", "H4")),
+            ("D1", TradingStyle.POSITION, ("MN1", "W1", "H4")),
+        ],
+    )
+    def test_correlation_for_all_styles(self, current_tf, trading_style, expected):
+        """Test correlation returns expected tuple for all trading styles."""
+        result = get_htf_correlation(current_tf, trading_style)
+        assert result == expected

--- a/docker/init/timescaledb/001_schema.sql
+++ b/docker/init/timescaledb/001_schema.sql
@@ -73,7 +73,8 @@ CREATE TABLE IF NOT EXISTS economic_events (
     previous        VARCHAR(50),
     actual          VARCHAR(50),
     source          VARCHAR(50),
-    created_at      TIMESTAMPTZ     DEFAULT NOW()
+    created_at      TIMESTAMPTZ     DEFAULT NOW(),
+    UNIQUE (event_time, currency, event_name)
 );
 
 CREATE INDEX IF NOT EXISTS idx_events_time_currency ON economic_events (event_time, currency);

--- a/ml/__init__.py
+++ b/ml/__init__.py
@@ -1,0 +1,1 @@
+"""ML package for AgentICTrader."""

--- a/ml/features/__init__.py
+++ b/ml/features/__init__.py
@@ -1,0 +1,19 @@
+"""Feature engineering modules for ML pipeline."""
+
+from ml.features.htf_selector import (
+    get_htf_correlation,
+    get_bias_timeframe,
+    get_structure_timeframe,
+    get_entry_timeframe,
+    TradingStyle,
+    SUPPORTED_TIMEFRAMES,
+)
+
+__all__ = [
+    "get_htf_correlation",
+    "get_bias_timeframe",
+    "get_structure_timeframe",
+    "get_entry_timeframe",
+    "TradingStyle",
+    "SUPPORTED_TIMEFRAMES",
+]

--- a/ml/features/htf_selector.py
+++ b/ml/features/htf_selector.py
@@ -1,0 +1,196 @@
+"""
+HTF 3-tier timeframe correlation logic (TTrades methodology).
+
+This module implements the 3-tier timeframe correlation system:
+- Higher TF (Bias Layer): Determines market direction
+- Mid TF (Structure Layer): Confirms alignment via CISD
+- Lower TF (Entry Layer): Precision timing for entry
+
+**Implements: Requirements FR-2.1**
+
+Example usage:
+    >>> from ml.features.htf_selector import TradingStyle, get_htf_correlation
+    >>> get_htf_correlation("M1", TradingStyle.SCALPING)
+    ('H1', 'M15', 'M1')
+    
+    >>> get_bias_timeframe("M5", TradingStyle.INTRADAY_STANDARD)
+    'D1'
+"""
+
+from enum import Enum
+from typing import Tuple
+
+
+class TradingStyle(Enum):
+    """
+    Trading style enum for 3-tier timeframe correlation.
+    
+    Each trading style has a specific 3-tier timeframe correlation:
+    - SCALPING: H1 → M15 → M1
+    - INTRADAY_STANDARD: D1 → H1 → M5
+    - INTRADAY_SIMPLE: D1 → H4 → M15
+    - SWING: W1 → D1 → H1
+    - POSITION: MN1 → W1 → H4
+    """
+    SCALPING = "SCALPING"
+    INTRADAY_STANDARD = "INTRADAY_STANDARD"
+    INTRADAY_SIMPLE = "INTRADAY_SIMPLE"
+    SWING = "SWING"
+    POSITION = "POSITION"
+
+
+# Supported timeframes constant (all valid timeframes in the system)
+SUPPORTED_TIMEFRAMES = frozenset({
+    "M1",   # 1 minute
+    "M3",   # 3 minutes
+    "M5",   # 5 minutes
+    "M15",  # 15 minutes
+    "M30",  # 30 minutes
+    "H1",   # 1 hour
+    "H4",   # 4 hours
+    "D1",   # 1 day
+    "W1",   # 1 week
+    "MN1",  # 1 month
+})
+
+
+# Trading style to 3-tier correlation mapping
+# Format: (Higher TF - Bias, Mid TF - Structure, Lower TF - Entry)
+_TRADING_STYLE_CORRELATIONS = {
+    TradingStyle.SCALPING: ("H1", "M15", "M1"),
+    TradingStyle.INTRADAY_STANDARD: ("D1", "H1", "M5"),
+    TradingStyle.INTRADAY_SIMPLE: ("D1", "H4", "M15"),
+    TradingStyle.SWING: ("W1", "D1", "H1"),
+    TradingStyle.POSITION: ("MN1", "W1", "H4"),
+}
+
+
+def _validate_inputs(current_tf: str, trading_style: TradingStyle) -> None:
+    """
+    Validate timeframe and trading style inputs.
+    
+    Args:
+        current_tf: Current timeframe to validate
+        trading_style: Trading style to validate
+        
+    Raises:
+        ValueError: If inputs are invalid
+    """
+    if current_tf is None:
+        raise ValueError("current_tf cannot be None")
+    
+    if trading_style is None:
+        raise ValueError("trading_style cannot be None")
+    
+    if current_tf not in SUPPORTED_TIMEFRAMES:
+        raise ValueError(
+            f"Unsupported timeframe: {current_tf}. "
+            f"Supported: {sorted(SUPPORTED_TIMEFRAMES)}"
+        )
+    
+    if not isinstance(trading_style, TradingStyle):
+        raise ValueError(
+            f"Invalid trading_style: {trading_style}. "
+            f"Must be a TradingStyle enum value."
+        )
+
+
+def get_htf_correlation(
+    current_tf: str, trading_style: TradingStyle
+) -> Tuple[str, str, str]:
+    """
+    Get 3-tier timeframe correlation for a given trading style.
+    
+    Args:
+        current_tf: Current timeframe (e.g., "M1", "H1", "D1")
+        trading_style: Trading style enum value
+        
+    Returns:
+        Tuple of (higher_tf, mid_tf, lower_tf) where:
+        - higher_tf: Bias layer timeframe
+        - mid_tf: Structure layer timeframe
+        - lower_tf: Entry layer timeframe
+        
+    Raises:
+        ValueError: If timeframe or trading style is invalid
+        
+    Example:
+        >>> get_htf_correlation("M1", TradingStyle.SCALPING)
+        ('H1', 'M15', 'M1')
+        
+    **Validates: Requirements FR-2.1**
+    """
+    _validate_inputs(current_tf, trading_style)
+    return _TRADING_STYLE_CORRELATIONS[trading_style]
+
+
+def get_bias_timeframe(current_tf: str, trading_style: TradingStyle) -> str:
+    """
+    Get the Higher TF (Bias Layer) for a given trading style.
+    
+    The bias layer determines market direction via Candle 2 closures
+    and Candle 3 expansions.
+    
+    Args:
+        current_tf: Current timeframe
+        trading_style: Trading style enum value
+        
+    Returns:
+        Higher timeframe for bias determination
+        
+    Example:
+        >>> get_bias_timeframe("M1", TradingStyle.SCALPING)
+        'H1'
+        
+    **Validates: Requirements FR-2.1**
+    """
+    higher_tf, _, _ = get_htf_correlation(current_tf, trading_style)
+    return higher_tf
+
+
+def get_structure_timeframe(current_tf: str, trading_style: TradingStyle) -> str:
+    """
+    Get the Mid TF (Structure Layer) for a given trading style.
+    
+    The structure layer confirms alignment via CISD (Change in State
+    of Delivery) or market structure shift.
+    
+    Args:
+        current_tf: Current timeframe
+        trading_style: Trading style enum value
+        
+    Returns:
+        Mid timeframe for structure confirmation
+        
+    Example:
+        >>> get_structure_timeframe("M1", TradingStyle.SCALPING)
+        'M15'
+        
+    **Validates: Requirements FR-2.1**
+    """
+    _, mid_tf, _ = get_htf_correlation(current_tf, trading_style)
+    return mid_tf
+
+
+def get_entry_timeframe(current_tf: str, trading_style: TradingStyle) -> str:
+    """
+    Get the Lower TF (Entry Layer) for a given trading style.
+    
+    The entry layer provides precision timing for entry (wait for wick
+    completion, enter on body expansion).
+    
+    Args:
+        current_tf: Current timeframe
+        trading_style: Trading style enum value
+        
+    Returns:
+        Lower timeframe for entry precision
+        
+    Example:
+        >>> get_entry_timeframe("M1", TradingStyle.SCALPING)
+        'M1'
+        
+    **Validates: Requirements FR-2.1**
+    """
+    _, _, lower_tf = get_htf_correlation(current_tf, trading_style)
+    return lower_tf

--- a/services/market-data/calendar_ingestion.py
+++ b/services/market-data/calendar_ingestion.py
@@ -1,0 +1,387 @@
+"""
+Economic calendar ingestion for AgentICTrader.
+
+This module provides async ingestion of economic calendar events from external sources
+(ForexFactory RSS or Investing.com API) and stores them in TimescaleDB.
+
+Features:
+- Fetches events for USD, EUR, GBP, XAU currencies
+- Validates impact levels (LOW, MEDIUM, HIGH)
+- Prevents duplicate event insertion using ON CONFLICT
+- Schedules daily refresh at 00:05 UTC via APScheduler
+- Connection pooling for performance
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, List, Optional
+import asyncpg
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+
+class CalendarSource(Enum):
+    """Supported calendar data sources."""
+    FOREXFACTORY = "forexfactory"
+    INVESTING_COM = "investing_com"
+
+
+@dataclass
+class EconomicEvent:
+    """
+    Represents a single economic calendar event.
+    
+    Attributes:
+        event_time: When the event occurs (TIMESTAMPTZ)
+        currency: Currency code (USD, EUR, GBP, XAU)
+        event_name: Name of the economic event
+        impact: Impact level - must be LOW, MEDIUM, or HIGH
+        forecast: Forecasted value (optional)
+        previous: Previous value (optional)
+        actual: Actual value (optional, filled after event)
+        source: Data source identifier
+    """
+    event_time: datetime
+    currency: str
+    event_name: str
+    impact: str
+    forecast: Optional[str] = None
+    previous: Optional[str] = None
+    actual: Optional[str] = None
+    source: str = "forexfactory"
+    
+    def __post_init__(self):
+        """Validate impact level after initialization."""
+        valid_impacts = {"LOW", "MEDIUM", "HIGH"}
+        if self.impact not in valid_impacts:
+            raise ValueError(
+                f"Invalid impact level: {self.impact}. "
+                f"Must be one of {valid_impacts}"
+            )
+
+
+class CalendarIngestion:
+    """
+    Async ingestion of economic calendar events into TimescaleDB.
+    
+    Features:
+    - Fetches events for USD, EUR, GBP, XAU
+    - Stores events with ON CONFLICT handling for duplicates
+    - Schedules daily refresh at 00:05 UTC
+    - Connection pooling for performance
+    """
+    
+    # Supported currencies
+    SUPPORTED_CURRENCIES = ["USD", "EUR", "GBP", "XAU"]
+    
+    def __init__(
+        self,
+        db_host: str,
+        db_port: int,
+        db_name: str,
+        db_user: str,
+        db_password: str,
+        min_pool_size: int = 5,
+        max_pool_size: int = 20,
+        source: CalendarSource = CalendarSource.FOREXFACTORY,
+    ):
+        """
+        Initialize the calendar ingestion service.
+        
+        Args:
+            db_host: Database host
+            db_port: Database port
+            db_name: Database name
+            db_user: Database user
+            db_password: Database password
+            min_pool_size: Minimum connection pool size
+            max_pool_size: Maximum connection pool size
+            source: Calendar data source
+        """
+        self._host = db_host
+        self._port = db_port
+        self._database = db_name
+        self._user = db_user
+        self._password = db_password
+        self._min_pool_size = min_pool_size
+        self._max_pool_size = max_pool_size
+        self._source = source
+        
+        self._pool: Optional[asyncpg.Pool] = None
+        self._scheduler: Optional[AsyncIOScheduler] = None
+    
+    async def connect(self) -> None:
+        """Create the connection pool."""
+        self._pool = await asyncpg.create_pool(
+            host=self._host,
+            port=self._port,
+            database=self._database,
+            user=self._user,
+            password=self._password,
+            min_size=self._min_pool_size,
+            max_size=self._max_pool_size,
+        )
+    
+    async def close(self) -> None:
+        """Close the connection pool and stop scheduler if running."""
+        if self._scheduler and self._scheduler.running:
+            self.stop_scheduler()
+        
+        if self._pool:
+            await self._pool.close()
+    
+    async def _fetch_events(self) -> List[EconomicEvent]:
+        """
+        Fetch economic events from the configured source.
+        
+        Returns:
+            List of EconomicEvent objects for supported currencies
+        """
+        # For testing, check if _fetch_from_source returns data
+        test_data = await self._fetch_from_source()
+        if test_data:
+            # Convert test data to EconomicEvent objects
+            events = []
+            for data in test_data:
+                event = EconomicEvent(
+                    event_time=data["event_time"],
+                    currency=data["currency"],
+                    event_name=data["event_name"],
+                    impact=data["impact"],
+                    forecast=data.get("forecast"),
+                    previous=data.get("previous"),
+                    actual=data.get("actual"),
+                    source="test",
+                )
+                events.append(event)
+            return events
+        
+        # Production path: fetch from configured source
+        if self._source == CalendarSource.FOREXFACTORY:
+            return await self._fetch_from_forexfactory()
+        elif self._source == CalendarSource.INVESTING_COM:
+            return await self._fetch_from_investing_com()
+        else:
+            return []
+    
+    async def _fetch_from_forexfactory(self) -> List[EconomicEvent]:
+        """
+        Fetch events from ForexFactory RSS feed.
+        
+        This is a placeholder implementation. In production, this would:
+        1. Fetch the ForexFactory RSS feed
+        2. Parse XML to extract events
+        3. Filter for supported currencies (USD, EUR, GBP, XAU)
+        4. Map impact levels to LOW/MEDIUM/HIGH
+        5. Return list of EconomicEvent objects
+        """
+        # Placeholder - would use aiohttp to fetch RSS feed
+        return []
+    
+    async def _fetch_from_investing_com(self) -> List[EconomicEvent]:
+        """
+        Fetch events from Investing.com API.
+        
+        Fetches economic calendar events for the next 7 days for supported currencies.
+        Uses the Investing.com economic calendar API endpoint.
+        
+        Returns:
+            List of EconomicEvent objects
+        """
+        import aiohttp
+        from datetime import timedelta
+        
+        events = []
+        
+        # Investing.com API endpoint (this is a simplified example)
+        # In production, you would need proper API credentials and endpoint
+        base_url = "https://www.investing.com/economic-calendar/Service/getCalendarFilteredData"
+        
+        # Calculate date range (next 7 days)
+        start_date = datetime.now(timezone.utc)
+        end_date = start_date + timedelta(days=7)
+        
+        # Map our currencies to Investing.com country codes
+        currency_to_country = {
+            "USD": "5",    # United States
+            "EUR": "72",   # Euro Zone
+            "GBP": "4",    # United Kingdom
+            "XAU": "5",    # Gold (use US as proxy for gold-related events)
+        }
+        
+        try:
+            async with aiohttp.ClientSession() as session:
+                for currency in self.SUPPORTED_CURRENCIES:
+                    country_id = currency_to_country.get(currency)
+                    if not country_id:
+                        continue
+                    
+                    # Prepare request payload
+                    payload = {
+                        "country[]": country_id,
+                        "dateFrom": start_date.strftime("%Y-%m-%d"),
+                        "dateTo": end_date.strftime("%Y-%m-%d"),
+                        "timeZone": "55",  # UTC
+                        "timeFilter": "timeRemain",
+                        "currentTab": "custom",
+                        "limit_from": "0",
+                    }
+                    
+                    headers = {
+                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+                        "X-Requested-With": "XMLHttpRequest",
+                    }
+                    
+                    try:
+                        async with session.post(
+                            base_url,
+                            data=payload,
+                            headers=headers,
+                            timeout=aiohttp.ClientTimeout(total=30),
+                        ) as response:
+                            if response.status == 200:
+                                data = await response.json()
+                                
+                                # Parse the response and extract events
+                                if "data" in data:
+                                    for row in data["data"]:
+                                        try:
+                                            # Parse event data
+                                            event_time_str = row.get("date")
+                                            event_name = row.get("event", "").strip()
+                                            impact_raw = row.get("importance", "1")
+                                            
+                                            # Skip if missing critical data
+                                            if not event_time_str or not event_name:
+                                                continue
+                                            
+                                            # Parse event time
+                                            event_time = datetime.fromtimestamp(
+                                                int(event_time_str),
+                                                tz=timezone.utc
+                                            )
+                                            
+                                            # Map impact level (1=LOW, 2=MEDIUM, 3=HIGH)
+                                            impact_map = {"1": "LOW", "2": "MEDIUM", "3": "HIGH"}
+                                            impact = impact_map.get(str(impact_raw), "LOW")
+                                            
+                                            # Extract forecast, previous, actual
+                                            forecast = row.get("forecast", "").strip() or None
+                                            previous = row.get("previous", "").strip() or None
+                                            actual = row.get("actual", "").strip() or None
+                                            
+                                            # Create event
+                                            event = EconomicEvent(
+                                                event_time=event_time,
+                                                currency=currency,
+                                                event_name=event_name,
+                                                impact=impact,
+                                                forecast=forecast,
+                                                previous=previous,
+                                                actual=actual,
+                                                source="investing_com",
+                                            )
+                                            events.append(event)
+                                            
+                                        except (KeyError, ValueError, TypeError) as e:
+                                            # Skip malformed events
+                                            continue
+                    
+                    except aiohttp.ClientError as e:
+                        # Log error but continue with other currencies
+                        print(f"Error fetching events for {currency}: {e}")
+                        continue
+        
+        except Exception as e:
+            print(f"Error in _fetch_from_investing_com: {e}")
+        
+        return events
+    
+    async def _fetch_from_source(self, **kwargs) -> List[Dict[str, Any]]:
+        """
+        Generic fetch method for testing purposes.
+        
+        This method is used by tests to mock the fetch behavior.
+        """
+        return []
+    
+    async def _store_event(self, event: EconomicEvent) -> None:
+        """
+        Store an economic event in TimescaleDB.
+        
+        Uses ON CONFLICT (event_time, currency, event_name) DO NOTHING
+        to prevent duplicate insertion.
+        
+        Args:
+            event: EconomicEvent to store
+        """
+        if not self._pool:
+            raise RuntimeError("Not connected. Call connect() first.")
+        
+        sql = """
+            INSERT INTO economic_events (
+                event_time, currency, event_name, impact,
+                forecast, previous, actual, source, created_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
+            ON CONFLICT (event_time, currency, event_name)
+            DO NOTHING
+        """
+        
+        async with self._pool.acquire() as conn:
+            await conn.execute(
+                sql,
+                event.event_time,
+                event.currency,
+                event.event_name,
+                event.impact,
+                event.forecast,
+                event.previous,
+                event.actual,
+                event.source,
+            )
+    
+    async def ingest_events(self) -> None:
+        """
+        Fetch and store all economic events.
+        
+        This is the main ingestion method that:
+        1. Fetches events from the configured source
+        2. Stores each event in TimescaleDB
+        3. Handles duplicates automatically via ON CONFLICT
+        """
+        events = await self._fetch_events()
+        
+        for event in events:
+            await self._store_event(event)
+    
+    def start_scheduler(self) -> None:
+        """
+        Start the APScheduler to run daily ingestion at 00:05 UTC.
+        
+        The scheduler will:
+        - Run ingest_events() every day at 00:05 UTC
+        - Use AsyncIOScheduler for async compatibility
+        - Use CronTrigger for precise scheduling
+        """
+        if self._scheduler is None:
+            self._scheduler = AsyncIOScheduler()
+        
+        # Schedule daily refresh at 00:05 UTC
+        self._scheduler.add_job(
+            self.ingest_events,
+            trigger=CronTrigger(hour=0, minute=5, timezone="UTC"),
+            id="daily_calendar_refresh",
+            name="Daily Economic Calendar Refresh",
+            replace_existing=True,
+        )
+        
+        self._scheduler.start()
+    
+    def stop_scheduler(self) -> None:
+        """Stop the scheduler."""
+        if self._scheduler and self._scheduler.running:
+            self._scheduler.shutdown(wait=False)


### PR DESCRIPTION
**Implement HTF 3-Tier Timeframe Correlation TTrades Fractal Model**
*Summary*
Implements a professional 3-tier timeframe correlation system based on TTrades Fractal Model methodology for multi-timeframe analysis: Higher TF (Bias) → Mid TF (Structure) → Lower TF (Entry).

*Changes*
Core Module (
htf_selector.py
): Implements TradingStyle enum and correlation functions supporting 5 trading styles (Scalping, Intraday Standard/Simple, Swing, Position)
Timeframe Support: Expands to 10 timeframes (M1, M3, M5, M15, M30, H1, H4, D1, W1, MN1)
API: Adds get_htf_correlation(), get_bias_timeframe(), get_structure_timeframe(), get_entry_timeframe()
Tests: Includes 44 comprehensive tests with property-based validation of timeframe hierarchy
Specs: Updates requirements.md (FR-2), design.md, and tasks.md with TTrades methodology