### PR TITLE
feat(task-24): Build ML inference FastAPI service

### DIFF
--- a/.kiro/specs/agentictrader-platform/tasks.md
+++ b/.kiro/specs/agentictrader-platform/tasks.md
@@ -329,7 +329,7 @@
     - Confirm all tests PASS (GREEN)
   - **23c. REFACTOR** — clean up, confirm GREEN
 
-- [ ] 24. Build ML inference FastAPI service
+- [x] 24. Build ML inference FastAPI service
   - Create ml/inference/main.py using FastAPI
   - Load models from MLflow registry: regime-classifier, pattern-detector, confluence-scorer
   - Expose POST /predict endpoint: accepts {instrument, timeframe, candles: list[OHLCV]} → returns {regime, patterns, confidence_score, htf_projections}

--- a/backend/tests/test_inference_service.py
+++ b/backend/tests/test_inference_service.py
@@ -1,0 +1,1319 @@
+﻿"""
+Integration tests for the ML Inference FastAPI service.
+
+Tests cover:
+- POST /predict endpoint: request/response schema, confidence thresholds, HTF projections
+- GET /health endpoint: liveness check
+- ModelRegistry: stub fallback when models not registered
+- InferenceEngine: feature extraction and prediction pipeline
+- CandleConsumer: Kafka message handling and rolling window
+- SetupPublisher: setups.detected message schema
+- Confidence threshold gating (< 0.65 discard, 0.65-0.74 log only, >= 0.75 publish)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+_WORKSPACE_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _WORKSPACE_ROOT not in sys.path:
+    sys.path.insert(0, _WORKSPACE_ROOT)
+
+from ml.inference.main import (
+    CandleConsumer,
+    InferenceEngine,
+    ModelRegistry,
+    OHLCVCandle,
+    PredictRequest,
+    SetupPublisher,
+    create_app,
+    CONFIDENCE_FLOOR,
+    CONFIDENCE_LOG_ONLY,
+    PATTERN_LABELS,
+    REGIME_CLASSES,
+    TOPIC_CANDLES,
+    TOPIC_SETUPS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_candles(n: int = 5, base_price: float = 1.1000) -> List[Dict[str, Any]]:
+    """Build a list of n synthetic OHLCV candle dicts."""
+    candles = []
+    price = base_price
+    for i in range(n):
+        open_ = price
+        close = price + 0.0010 * (1 if i % 2 == 0 else -1)
+        high = max(open_, close) + 0.0005
+        low = min(open_, close) - 0.0005
+        # Use minutes to avoid hour overflow for large n
+        hour = (i * 5) // 60
+        minute = (i * 5) % 60
+        candles.append({
+            "time": f"2024-01-01T{hour:02d}:{minute:02d}:00Z",
+            "open": round(open_, 5),
+            "high": round(high, 5),
+            "low": round(low, 5),
+            "close": round(close, 5),
+            "volume": 1000.0 + i * 100,
+        })
+        price = close
+    return candles
+
+
+def _make_ohlcv_models(n: int = 5) -> List[OHLCVCandle]:
+    """Build a list of n OHLCVCandle Pydantic models."""
+    raw = _make_candles(n)
+    return [OHLCVCandle(**c) for c in raw]
+
+
+@pytest.fixture
+def sample_candles() -> List[Dict[str, Any]]:
+    return _make_candles(10)
+
+
+@pytest.fixture
+def sample_ohlcv_models() -> List[OHLCVCandle]:
+    return _make_ohlcv_models(10)
+
+
+@pytest.fixture
+def stub_registry() -> ModelRegistry:
+    """ModelRegistry with all models set to None (stub mode)."""
+    with patch.object(ModelRegistry, "load", return_value=None):
+        registry = ModelRegistry(tracking_uri="http://localhost:5000")
+        registry._regime_model = None
+        registry._pattern_model = None
+        registry._confluence_model = None
+        registry._loaded = True
+    return registry
+
+
+@pytest.fixture
+def mock_regime_model():
+    """Mock sklearn-compatible regime classifier."""
+    model = Mock()
+    model.predict = Mock(return_value=np.array([0]))  # TRENDING_BULLISH
+    return model
+
+
+@pytest.fixture
+def mock_pattern_model():
+    """Mock sklearn-compatible multi-label pattern detector."""
+    model = Mock()
+    # predict_proba returns list of (n_samples, 2) arrays  one per label
+    model.predict_proba = Mock(
+        return_value=[
+            np.array([[0.3, 0.7]]),  # BOS_CONFIRMED active
+            np.array([[0.8, 0.2]]),  # CHOCH_DETECTED inactive
+            np.array([[0.4, 0.6]]),  # BEARISH_ARRAY_REJECTION active
+            np.array([[0.9, 0.1]]),  # BULLISH_ARRAY_BOUNCE inactive
+            np.array([[0.3, 0.7]]),  # FVG_PRESENT active
+            np.array([[0.8, 0.2]]),  # LIQUIDITY_SWEEP inactive
+            np.array([[0.9, 0.1]]),  # ORDER_BLOCK inactive
+            np.array([[0.8, 0.2]]),  # INDUCEMENT inactive
+        ]
+    )
+    return model
+
+
+@pytest.fixture
+def mock_confluence_model():
+    """Mock sklearn-compatible confluence scorer."""
+    model = Mock()
+    model.predict_proba = Mock(return_value=np.array([[0.15, 0.85]]))  # 0.85 confidence
+    return model
+
+
+@pytest.fixture
+def registry_with_mocks(mock_regime_model, mock_pattern_model, mock_confluence_model):
+    """ModelRegistry with mock models injected."""
+    with patch.object(ModelRegistry, "load", return_value=None):
+        registry = ModelRegistry(tracking_uri="http://localhost:5000")
+        registry._regime_model = mock_regime_model
+        registry._pattern_model = mock_pattern_model
+        registry._confluence_model = mock_confluence_model
+        registry._loaded = True
+    return registry
+
+
+@pytest.fixture
+def inference_engine(registry_with_mocks) -> InferenceEngine:
+    return InferenceEngine(registry_with_mocks)
+
+
+@pytest.fixture
+def test_client(stub_registry) -> TestClient:
+    """FastAPI TestClient with stub models (no Kafka)."""
+    with patch("ml.inference.main.ModelRegistry", return_value=stub_registry):
+        app = create_app(registry=stub_registry)
+    return TestClient(app)
+
+
+# ===========================================================================
+# 1. Constants and schema tests
+# ===========================================================================
+
+
+class TestConstants:
+    """Verify module-level constants match the spec."""
+
+    def test_confidence_floor_is_0_65(self):
+        """CONFIDENCE_FLOOR must be 0.65 (hard discard threshold)."""
+        assert CONFIDENCE_FLOOR == 0.65
+
+    def test_confidence_log_only_is_0_75(self):
+        """CONFIDENCE_LOG_ONLY must be 0.75 (publish threshold)."""
+        assert CONFIDENCE_LOG_ONLY == 0.75
+
+    def test_topic_candles_name(self):
+        """Kafka input topic must be market.candles."""
+        assert TOPIC_CANDLES == "market.candles"
+
+    def test_topic_setups_name(self):
+        """Kafka output topic must be setups.detected."""
+        assert TOPIC_SETUPS == "setups.detected"
+
+    def test_regime_classes_count(self):
+        """Five regime classes must be defined."""
+        assert len(REGIME_CLASSES) == 5
+
+    def test_regime_classes_values(self):
+        """All five regime class labels must be present."""
+        expected = {
+            "TRENDING_BULLISH",
+            "TRENDING_BEARISH",
+            "RANGING",
+            "BREAKOUT",
+            "NEWS_DRIVEN",
+        }
+        assert set(REGIME_CLASSES) == expected
+
+    def test_pattern_labels_count(self):
+        """Eight pattern labels must be defined."""
+        assert len(PATTERN_LABELS) == 8
+
+    def test_pattern_labels_values(self):
+        """All eight pattern labels must be present."""
+        expected = {
+            "BOS_CONFIRMED",
+            "CHOCH_DETECTED",
+            "BEARISH_ARRAY_REJECTION",
+            "BULLISH_ARRAY_BOUNCE",
+            "FVG_PRESENT",
+            "LIQUIDITY_SWEEP",
+            "ORDER_BLOCK",
+            "INDUCEMENT",
+        }
+        assert set(PATTERN_LABELS) == expected
+
+
+# ===========================================================================
+# 2. ModelRegistry tests
+# ===========================================================================
+
+
+class TestModelRegistry:
+    """Tests for ModelRegistry  model loading and stub fallback."""
+
+    def test_registry_instantiates(self):
+        """ModelRegistry can be instantiated with a tracking URI."""
+        with patch("mlflow.set_tracking_uri"):
+            registry = ModelRegistry(tracking_uri="http://localhost:5000")
+        assert registry is not None
+
+    def test_registry_not_loaded_before_load_called(self):
+        """loaded property is False before load() is called."""
+        with patch("mlflow.set_tracking_uri"):
+            registry = ModelRegistry(tracking_uri="http://localhost:5000")
+        assert registry.loaded is False
+
+    def test_registry_loaded_after_load_called(self, stub_registry):
+        """loaded property is True after load() completes."""
+        assert stub_registry.loaded is True
+
+    def test_stub_regime_returns_ranging(self, stub_registry):
+        """Stub regime model returns RANGING by default."""
+        X = np.zeros((1, 10))
+        result = stub_registry.predict_regime(X)
+        assert result == "RANGING"
+
+    def test_stub_patterns_returns_empty_list(self, stub_registry):
+        """Stub pattern model returns empty list by default."""
+        X = np.zeros((1, 10))
+        result = stub_registry.predict_patterns(X)
+        assert result == []
+
+    def test_stub_confidence_returns_zero(self, stub_registry):
+        """Stub confluence model returns 0.0 by default."""
+        X = np.zeros((1, 10))
+        result = stub_registry.predict_confidence(X)
+        assert result == 0.0
+
+    def test_regime_model_returns_class_label(self, registry_with_mocks):
+        """predict_regime returns a valid REGIME_CLASSES label."""
+        X = np.zeros((1, 10))
+        result = registry_with_mocks.predict_regime(X)
+        assert result in REGIME_CLASSES
+
+    def test_pattern_model_returns_list_of_labels(self, registry_with_mocks):
+        """predict_patterns returns a list of PATTERN_LABELS strings."""
+        X = np.zeros((1, 10))
+        result = registry_with_mocks.predict_patterns(X)
+        assert isinstance(result, list)
+        for label in result:
+            assert label in PATTERN_LABELS
+
+    def test_confidence_model_returns_float_in_range(self, registry_with_mocks):
+        """predict_confidence returns a float in [0.0, 1.0]."""
+        X = np.zeros((1, 10))
+        result = registry_with_mocks.predict_confidence(X)
+        assert isinstance(result, float)
+        assert 0.0 <= result <= 1.0
+
+    def test_load_falls_back_to_stub_when_mlflow_unavailable(self):
+        """load() installs stub predictors when MLflow registry is unreachable."""
+        with patch("mlflow.set_tracking_uri"), \
+             patch("mlflow.tracking.MlflowClient") as mock_client_cls:
+            mock_client = Mock()
+            mock_client.get_latest_versions.side_effect = Exception("Connection refused")
+            mock_client_cls.return_value = mock_client
+
+            registry = ModelRegistry(tracking_uri="http://localhost:5000")
+            registry.load()
+
+        assert registry.loaded is True
+        # All models should be None (stub mode)
+        assert registry._regime_model is None
+        assert registry._pattern_model is None
+        assert registry._confluence_model is None
+
+
+# ===========================================================================
+# 3. InferenceEngine tests
+# ===========================================================================
+
+
+class TestInferenceEngine:
+    """Tests for InferenceEngine  feature extraction and prediction."""
+
+    def test_engine_instantiates(self, stub_registry):
+        """InferenceEngine can be instantiated with a registry."""
+        engine = InferenceEngine(stub_registry)
+        assert engine is not None
+
+    def test_predict_returns_required_keys(self, inference_engine, sample_candles):
+        """predict() returns a dict with all required keys."""
+        result = inference_engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        required_keys = {
+            "time",
+            "regime",
+            "patterns",
+            "confidence_score",
+            "htf_projections",
+            "entry_price",
+            "sl_price",
+            "tp_price",
+        }
+        assert required_keys.issubset(set(result.keys()))
+
+    def test_predict_regime_is_valid_class(self, inference_engine, sample_candles):
+        """predict() returns a valid regime class label."""
+        result = inference_engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        assert result["regime"] in REGIME_CLASSES
+
+    def test_predict_patterns_is_list(self, inference_engine, sample_candles):
+        """predict() returns patterns as a list."""
+        result = inference_engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        assert isinstance(result["patterns"], list)
+
+    def test_predict_confidence_score_in_range(self, inference_engine, sample_candles):
+        """predict() returns confidence_score in [0.0, 1.0]."""
+        result = inference_engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        assert 0.0 <= result["confidence_score"] <= 1.0
+
+    def test_predict_htf_projections_has_required_fields(self, inference_engine, sample_candles):
+        """predict() returns htf_projections with all required fields."""
+        result = inference_engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        htf = result["htf_projections"]
+        required_htf_keys = {
+            "htf_timeframe",
+            "htf_open",
+            "htf_high",
+            "htf_low",
+            "open_bias",
+            "htf_high_proximity_pct",
+            "htf_low_proximity_pct",
+            "htf_body_pct",
+            "htf_upper_wick_pct",
+            "htf_lower_wick_pct",
+            "htf_close_position",
+        }
+        assert required_htf_keys.issubset(set(htf.keys()))
+
+    def test_predict_open_bias_is_valid_enum(self, inference_engine, sample_candles):
+        """predict() returns open_bias in {BULLISH, BEARISH, NEUTRAL}."""
+        result = inference_engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        assert result["htf_projections"]["open_bias"] in {"BULLISH", "BEARISH", "NEUTRAL"}
+
+    def test_predict_raises_on_single_candle(self, inference_engine):
+        """predict() raises ValueError when fewer than 2 candles provided."""
+        single_candle = _make_candles(1)
+        with pytest.raises(ValueError, match="At least 2 candles"):
+            inference_engine.predict(
+                instrument="EURUSD",
+                timeframe="M5",
+                candles=single_candle,
+            )
+
+    def test_predict_trade_levels_none_when_confidence_below_floor(self, stub_registry, sample_candles):
+        """entry/sl/tp are None when confidence < CONFIDENCE_FLOOR (stub returns 0.0)."""
+        engine = InferenceEngine(stub_registry)
+        result = engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        # Stub confidence is 0.0 < 0.65
+        assert result["entry_price"] is None
+        assert result["sl_price"] is None
+        assert result["tp_price"] is None
+
+    def test_predict_trade_levels_set_when_confidence_above_floor(
+        self, registry_with_mocks, sample_candles
+    ):
+        """entry/sl/tp are set when confidence >= CONFIDENCE_FLOOR and bias is not NEUTRAL."""
+        engine = InferenceEngine(registry_with_mocks)
+        result = engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        # Mock confidence is 0.85 >= 0.65
+        # Trade levels depend on open_bias  if NEUTRAL they remain None
+        confidence = result["confidence_score"]
+        assert confidence >= CONFIDENCE_FLOOR
+        # If bias is directional, levels should be set
+        if result["htf_projections"]["open_bias"] in ("BULLISH", "BEARISH"):
+            assert result["entry_price"] is not None
+            assert result["sl_price"] is not None
+            assert result["tp_price"] is not None
+
+    def test_predict_time_is_string(self, inference_engine, sample_candles):
+        """predict() returns time as a string."""
+        result = inference_engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        assert isinstance(result["time"], str)
+
+    def test_predict_htf_timeframe_is_higher_than_input(
+        self, inference_engine, sample_candles
+    ):
+        """HTF timeframe returned is always a higher timeframe than the input.
+
+        The engine uses INTRADAY_STANDARD style which maps all inputs to D1 bias.
+        The key invariant is that the returned htf_timeframe is a valid timeframe
+        string and is present in the htf_projections dict.
+        """
+        result = inference_engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        htf_tf = result["htf_projections"]["htf_timeframe"]
+        # Must be a non-empty string
+        assert isinstance(htf_tf, str)
+        assert len(htf_tf) > 0
+        # Must be a known timeframe
+        valid_timeframes = {"M1", "M3", "M5", "M15", "M30", "H1", "H4", "D1", "W1", "MN1"}
+        assert htf_tf in valid_timeframes, f"Unknown HTF timeframe: {htf_tf}"
+        # For M5 input with INTRADAY_STANDARD style, bias TF should be D1
+        assert htf_tf == "D1", f"Expected D1 for M5 INTRADAY_STANDARD, got {htf_tf}"
+
+
+# ===========================================================================
+# 4. POST /predict endpoint tests
+# ===========================================================================
+
+
+class TestPredictEndpoint:
+    """Integration tests for POST /predict."""
+
+    @pytest.fixture
+    def client(self, stub_registry) -> TestClient:
+        app = create_app(registry=stub_registry)
+        return TestClient(app)
+
+    def _predict_payload(self, n_candles: int = 5, instrument: str = "EURUSD", timeframe: str = "M5") -> Dict:
+        candles = [
+            {
+                "time": f"2024-01-01T{i:02d}:00:00Z",
+                "open": 1.1000 + i * 0.001,
+                "high": 1.1010 + i * 0.001,
+                "low": 1.0990 + i * 0.001,
+                "close": 1.1005 + i * 0.001,
+                "volume": 1000.0,
+            }
+            for i in range(n_candles)
+        ]
+        return {"instrument": instrument, "timeframe": timeframe, "candles": candles}
+
+    def test_predict_returns_200(self, client):
+        """POST /predict returns HTTP 200 for valid payload."""
+        response = client.post("/predict", json=self._predict_payload())
+        assert response.status_code == 200
+
+    def test_predict_response_has_instrument(self, client):
+        """POST /predict response includes instrument field."""
+        response = client.post("/predict", json=self._predict_payload(instrument="XAUUSD"))
+        assert response.status_code == 200
+        assert response.json()["instrument"] == "XAUUSD"
+
+    def test_predict_response_has_timeframe(self, client):
+        """POST /predict response includes timeframe field."""
+        response = client.post("/predict", json=self._predict_payload(timeframe="H1"))
+        assert response.status_code == 200
+        assert response.json()["timeframe"] == "H1"
+
+    def test_predict_response_has_regime(self, client):
+        """POST /predict response includes regime field."""
+        response = client.post("/predict", json=self._predict_payload())
+        assert response.status_code == 200
+        assert "regime" in response.json()
+        assert response.json()["regime"] in REGIME_CLASSES
+
+    def test_predict_response_has_patterns_list(self, client):
+        """POST /predict response includes patterns as a list."""
+        response = client.post("/predict", json=self._predict_payload())
+        assert response.status_code == 200
+        assert isinstance(response.json()["patterns"], list)
+
+    def test_predict_response_has_confidence_score(self, client):
+        """POST /predict response includes confidence_score in [0, 1]."""
+        response = client.post("/predict", json=self._predict_payload())
+        assert response.status_code == 200
+        score = response.json()["confidence_score"]
+        assert 0.0 <= score <= 1.0
+
+    def test_predict_response_has_htf_projections(self, client):
+        """POST /predict response includes htf_projections object."""
+        response = client.post("/predict", json=self._predict_payload())
+        assert response.status_code == 200
+        htf = response.json()["htf_projections"]
+        assert "htf_open" in htf
+        assert "htf_high" in htf
+        assert "htf_low" in htf
+        assert "open_bias" in htf
+
+    def test_predict_response_htf_open_bias_valid(self, client):
+        """POST /predict response open_bias is in valid enum set."""
+        response = client.post("/predict", json=self._predict_payload())
+        assert response.status_code == 200
+        bias = response.json()["htf_projections"]["open_bias"]
+        assert bias in {"BULLISH", "BEARISH", "NEUTRAL"}
+
+    def test_predict_response_has_time_field(self, client):
+        """POST /predict response includes time field."""
+        response = client.post("/predict", json=self._predict_payload())
+        assert response.status_code == 200
+        assert "time" in response.json()
+
+    def test_predict_rejects_single_candle(self, client):
+        """POST /predict returns 422 when only 1 candle provided."""
+        payload = self._predict_payload(n_candles=1)
+        response = client.post("/predict", json=payload)
+        assert response.status_code == 422
+
+    def test_predict_rejects_empty_candles(self, client):
+        """POST /predict returns 422 when candles list is empty."""
+        payload = {"instrument": "EURUSD", "timeframe": "M5", "candles": []}
+        response = client.post("/predict", json=payload)
+        assert response.status_code == 422
+
+    def test_predict_accepts_optional_reference_prices(self, client):
+        """POST /predict accepts optional daily_open, weekly_open, true_day_open."""
+        payload = self._predict_payload()
+        payload["daily_open"] = 1.1000
+        payload["weekly_open"] = 1.0950
+        payload["true_day_open"] = 1.1010
+        response = client.post("/predict", json=payload)
+        assert response.status_code == 200
+
+    def test_predict_all_supported_instruments(self, client):
+        """POST /predict works for all 12 supported instruments."""
+        instruments = [
+            "XAUUSD", "EURUSD", "GBPUSD", "EURAUD", "GBPAUD",
+            "USDJPY", "US100", "US30", "US500", "GER40", "BTCUSD", "ETHUSD",
+        ]
+        for instrument in instruments:
+            response = client.post("/predict", json=self._predict_payload(instrument=instrument))
+            assert response.status_code == 200, f"Failed for instrument {instrument}"
+
+    def test_predict_all_supported_timeframes(self, client):
+        """POST /predict works for all supported timeframes."""
+        timeframes = ["M1", "M5", "M15", "H1", "H4", "D1"]
+        for tf in timeframes:
+            response = client.post("/predict", json=self._predict_payload(timeframe=tf))
+            assert response.status_code == 200, f"Failed for timeframe {tf}"
+
+    def test_predict_stub_confidence_below_floor_no_trade_levels(self, client):
+        """Stub confidence (0.0) means entry/sl/tp are null in response."""
+        response = client.post("/predict", json=self._predict_payload())
+        assert response.status_code == 200
+        data = response.json()
+        # Stub returns 0.0 confidence < 0.65 floor
+        assert data["entry_price"] is None
+        assert data["sl_price"] is None
+        assert data["tp_price"] is None
+
+
+# ===========================================================================
+# 5. GET /health endpoint tests
+# ===========================================================================
+
+
+class TestHealthEndpoint:
+    """Tests for GET /health liveness check."""
+
+    @pytest.fixture
+    def client(self, stub_registry) -> TestClient:
+        app = create_app(registry=stub_registry)
+        return TestClient(app)
+
+    def test_health_returns_200(self, client):
+        """GET /health returns HTTP 200."""
+        response = client.get("/health")
+        assert response.status_code == 200
+
+    def test_health_response_has_status_ok(self, client):
+        """GET /health response has status='ok'."""
+        response = client.get("/health")
+        assert response.json()["status"] == "ok"
+
+    def test_health_response_has_models_loaded(self, client):
+        """GET /health response includes models_loaded boolean."""
+        response = client.get("/health")
+        assert "models_loaded" in response.json()
+        assert isinstance(response.json()["models_loaded"], bool)
+
+    def test_health_response_has_kafka_consumer_running(self, client):
+        """GET /health response includes kafka_consumer_running boolean."""
+        response = client.get("/health")
+        assert "kafka_consumer_running" in response.json()
+        assert isinstance(response.json()["kafka_consumer_running"], bool)
+
+    def test_health_models_loaded_true_when_registry_loaded(self, stub_registry):
+        """models_loaded is True when registry.loaded is True."""
+        app = create_app(registry=stub_registry)
+        client = TestClient(app)
+        response = client.get("/health")
+        assert response.json()["models_loaded"] is True
+
+    def test_health_kafka_consumer_false_without_kafka(self, stub_registry):
+        """kafka_consumer_running is False when no Kafka consumer is running."""
+        app = create_app(registry=stub_registry)
+        client = TestClient(app)
+        response = client.get("/health")
+        # No Kafka in test environment
+        assert response.json()["kafka_consumer_running"] is False
+
+
+# ===========================================================================
+# 6. Confidence threshold gating tests
+# ===========================================================================
+
+
+class TestConfidenceThresholds:
+    """Tests for confidence threshold gating in InferenceEngine._derive_trade_levels."""
+
+    def _make_htf_proj(self, open_bias: str = "BULLISH") -> Dict[str, Any]:
+        return {
+            "htf_timeframe": "H1",
+            "htf_open": 1.1000,
+            "htf_high": 1.1200,
+            "htf_low": 1.0800,
+            "open_bias": open_bias,
+            "htf_high_proximity_pct": 30.0,
+            "htf_low_proximity_pct": 70.0,
+            "htf_body_pct": 60.0,
+            "htf_upper_wick_pct": 20.0,
+            "htf_lower_wick_pct": 20.0,
+            "htf_close_position": 0.8,
+        }
+
+    def _make_candle(self, close: float = 1.1050) -> Dict[str, Any]:
+        return {"time": "2024-01-01T00:00:00Z", "open": 1.1000, "high": 1.1100, "low": 1.0950, "close": close, "volume": 1000}
+
+    def test_confidence_below_floor_returns_none_levels(self, stub_registry):
+        """confidence < 0.65 -> entry/sl/tp all None."""
+        engine = InferenceEngine(stub_registry)
+        entry, sl, tp = engine._derive_trade_levels(
+            current_candle=self._make_candle(),
+            htf_proj=self._make_htf_proj("BULLISH"),
+            confidence_score=0.60,
+        )
+        assert entry is None
+        assert sl is None
+        assert tp is None
+
+    def test_confidence_at_floor_minus_epsilon_returns_none(self, stub_registry):
+        """confidence = 0.6499 (just below floor) -> None levels."""
+        engine = InferenceEngine(stub_registry)
+        entry, sl, tp = engine._derive_trade_levels(
+            current_candle=self._make_candle(),
+            htf_proj=self._make_htf_proj("BULLISH"),
+            confidence_score=0.6499,
+        )
+        assert entry is None
+
+    def test_confidence_at_floor_returns_levels(self, stub_registry):
+        """confidence = 0.65 (at floor) -> trade levels set for directional bias."""
+        engine = InferenceEngine(stub_registry)
+        entry, sl, tp = engine._derive_trade_levels(
+            current_candle=self._make_candle(close=1.1050),
+            htf_proj=self._make_htf_proj("BULLISH"),
+            confidence_score=0.65,
+        )
+        assert entry is not None
+        assert sl is not None
+        assert tp is not None
+
+    def test_confidence_above_floor_returns_levels(self, stub_registry):
+        """confidence = 0.85 -> trade levels set."""
+        engine = InferenceEngine(stub_registry)
+        entry, sl, tp = engine._derive_trade_levels(
+            current_candle=self._make_candle(close=1.1050),
+            htf_proj=self._make_htf_proj("BULLISH"),
+            confidence_score=0.85,
+        )
+        assert entry is not None
+
+    def test_bullish_bias_entry_is_close_sl_is_htf_low(self, stub_registry):
+        """Bullish bias: entry=close, sl=htf_low, tp=htf_high."""
+        engine = InferenceEngine(stub_registry)
+        close = 1.1050
+        htf_proj = self._make_htf_proj("BULLISH")
+        entry, sl, tp = engine._derive_trade_levels(
+            current_candle=self._make_candle(close=close),
+            htf_proj=htf_proj,
+            confidence_score=0.80,
+        )
+        assert entry == pytest.approx(close)
+        assert sl == pytest.approx(htf_proj["htf_low"])
+        assert tp == pytest.approx(htf_proj["htf_high"])
+
+    def test_bearish_bias_entry_is_close_sl_is_htf_high(self, stub_registry):
+        """Bearish bias: entry=close, sl=htf_high, tp=htf_low."""
+        engine = InferenceEngine(stub_registry)
+        close = 1.1050
+        htf_proj = self._make_htf_proj("BEARISH")
+        entry, sl, tp = engine._derive_trade_levels(
+            current_candle=self._make_candle(close=close),
+            htf_proj=htf_proj,
+            confidence_score=0.80,
+        )
+        assert entry == pytest.approx(close)
+        assert sl == pytest.approx(htf_proj["htf_high"])
+        assert tp == pytest.approx(htf_proj["htf_low"])
+
+    def test_neutral_bias_returns_none_levels(self, stub_registry):
+        """NEUTRAL bias -> no trade levels regardless of confidence."""
+        engine = InferenceEngine(stub_registry)
+        entry, sl, tp = engine._derive_trade_levels(
+            current_candle=self._make_candle(),
+            htf_proj=self._make_htf_proj("NEUTRAL"),
+            confidence_score=0.90,
+        )
+        assert entry is None
+        assert sl is None
+        assert tp is None
+
+
+# ===========================================================================
+# 7. setups.detected message schema tests
+# ===========================================================================
+
+
+class TestSetupsDetectedSchema:
+    """Tests for the setups.detected Kafka message schema."""
+
+    REQUIRED_FIELDS = {
+        "instrument",
+        "timeframe",
+        "time",
+        "regime",
+        "patterns",
+        "confidence_score",
+        "htf_open",
+        "htf_high",
+        "htf_low",
+        "open_bias",
+        "entry_price",
+        "sl_price",
+        "tp_price",
+    }
+
+    def _build_setup_msg(self, **overrides) -> Dict[str, Any]:
+        base = {
+            "instrument": "EURUSD",
+            "timeframe": "M5",
+            "time": "2024-01-01T10:00:00Z",
+            "regime": "TRENDING_BULLISH",
+            "patterns": ["BOS_CONFIRMED", "FVG_PRESENT"],
+            "confidence_score": 0.82,
+            "htf_open": 1.1000,
+            "htf_high": 1.1200,
+            "htf_low": 1.0800,
+            "open_bias": "BULLISH",
+            "entry_price": 1.1050,
+            "sl_price": 1.0800,
+            "tp_price": 1.1200,
+        }
+        base.update(overrides)
+        return base
+
+    def test_setup_msg_has_all_required_fields(self):
+        """setups.detected message contains all 13 required fields."""
+        msg = self._build_setup_msg()
+        assert self.REQUIRED_FIELDS.issubset(set(msg.keys()))
+
+    def test_setup_msg_instrument_is_string(self):
+        """instrument field is a string."""
+        msg = self._build_setup_msg()
+        assert isinstance(msg["instrument"], str)
+
+    def test_setup_msg_timeframe_is_string(self):
+        """timeframe field is a string."""
+        msg = self._build_setup_msg()
+        assert isinstance(msg["timeframe"], str)
+
+    def test_setup_msg_regime_is_valid_class(self):
+        """regime field is a valid REGIME_CLASSES value."""
+        msg = self._build_setup_msg()
+        assert msg["regime"] in REGIME_CLASSES
+
+    def test_setup_msg_patterns_is_list(self):
+        """patterns field is a list."""
+        msg = self._build_setup_msg()
+        assert isinstance(msg["patterns"], list)
+
+    def test_setup_msg_confidence_score_in_range(self):
+        """confidence_score is in [0.0, 1.0]."""
+        msg = self._build_setup_msg()
+        assert 0.0 <= msg["confidence_score"] <= 1.0
+
+    def test_setup_msg_open_bias_valid(self):
+        """open_bias is in {BULLISH, BEARISH, NEUTRAL}."""
+        msg = self._build_setup_msg()
+        assert msg["open_bias"] in {"BULLISH", "BEARISH", "NEUTRAL"}
+
+    def test_setup_msg_is_json_serialisable(self):
+        """setups.detected message can be JSON-serialised."""
+        msg = self._build_setup_msg()
+        serialised = json.dumps(msg, default=str)
+        deserialised = json.loads(serialised)
+        assert deserialised["instrument"] == msg["instrument"]
+        assert deserialised["confidence_score"] == msg["confidence_score"]
+
+    def test_setup_msg_htf_levels_are_numeric(self):
+        """htf_open, htf_high, htf_low are numeric."""
+        msg = self._build_setup_msg()
+        assert isinstance(msg["htf_open"], (int, float))
+        assert isinstance(msg["htf_high"], (int, float))
+        assert isinstance(msg["htf_low"], (int, float))
+
+    def test_setup_msg_htf_high_gte_htf_low(self):
+        """htf_high >= htf_low (valid OHLC range)."""
+        msg = self._build_setup_msg()
+        assert msg["htf_high"] >= msg["htf_low"]
+
+
+# ===========================================================================
+# 8. CandleConsumer rolling window tests
+# ===========================================================================
+
+
+class TestCandleConsumer:
+    """Tests for CandleConsumer rolling window and message handling."""
+
+    def _make_consumer(self) -> CandleConsumer:
+        """Build a CandleConsumer with mock engine and publisher."""
+        mock_engine = Mock(spec=InferenceEngine)
+        mock_engine.predict = Mock(return_value={
+            "time": "2024-01-01T00:00:00Z",
+            "regime": "RANGING",
+            "patterns": [],
+            "confidence_score": 0.0,
+            "htf_projections": {
+                "htf_timeframe": "H1",
+                "htf_open": 1.1000,
+                "htf_high": 1.1200,
+                "htf_low": 1.0800,
+                "open_bias": "NEUTRAL",
+                "htf_high_proximity_pct": 50.0,
+                "htf_low_proximity_pct": 50.0,
+                "htf_body_pct": 60.0,
+                "htf_upper_wick_pct": 20.0,
+                "htf_lower_wick_pct": 20.0,
+                "htf_close_position": 0.5,
+            },
+            "entry_price": None,
+            "sl_price": None,
+            "tp_price": None,
+        })
+        mock_publisher = Mock(spec=SetupPublisher)
+        mock_publisher.publish = AsyncMock()
+        return CandleConsumer(
+            bootstrap_servers="localhost:9092",
+            engine=mock_engine,
+            publisher=mock_publisher,
+        )
+
+    def _make_candle_msg(
+        self,
+        instrument: str = "EURUSD",
+        timeframe: str = "M5",
+        complete: bool = True,
+        idx: int = 0,
+    ) -> Dict[str, Any]:
+        return {
+            "instrument": instrument,
+            "timeframe": timeframe,
+            "time": f"2024-01-01T{idx:02d}:00:00Z",
+            "open": 1.1000 + idx * 0.001,
+            "high": 1.1010 + idx * 0.001,
+            "low": 1.0990 + idx * 0.001,
+            "close": 1.1005 + idx * 0.001,
+            "volume": 1000.0,
+            "complete": complete,
+            "source": "oanda",
+        }
+
+    @pytest.mark.asyncio
+    async def test_incomplete_candle_not_processed(self):
+        """Incomplete candles (complete=False) are ignored."""
+        consumer = self._make_consumer()
+        msg = self._make_candle_msg(complete=False)
+        await consumer._handle_message(msg)
+        consumer.engine.predict.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_complete_candle_triggers_inference(self):
+        """Complete candles trigger inference after 2+ candles in window."""
+        consumer = self._make_consumer()
+        # Send 2 complete candles to build the window
+        for i in range(2):
+            await consumer._handle_message(self._make_candle_msg(complete=True, idx=i))
+        consumer.engine.predict.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_single_complete_candle_no_inference(self):
+        """Single complete candle does not trigger inference (need >= 2)."""
+        consumer = self._make_consumer()
+        await consumer._handle_message(self._make_candle_msg(complete=True, idx=0))
+        consumer.engine.predict.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rolling_window_capped_at_window_size(self):
+        """Rolling window is capped at WINDOW_SIZE (50) candles."""
+        consumer = self._make_consumer()
+        key = "EURUSD:M5"
+        # Send WINDOW_SIZE + 10 candles
+        for i in range(CandleConsumer.WINDOW_SIZE + 10):
+            await consumer._handle_message(self._make_candle_msg(complete=True, idx=i))
+        assert len(consumer._windows[key]) == CandleConsumer.WINDOW_SIZE
+
+    @pytest.mark.asyncio
+    async def test_separate_windows_per_instrument_timeframe(self):
+        """Separate rolling windows maintained per instrument:timeframe key."""
+        consumer = self._make_consumer()
+        for i in range(3):
+            await consumer._handle_message(
+                self._make_candle_msg(instrument="EURUSD", timeframe="M5", complete=True, idx=i)
+            )
+        for i in range(2):
+            await consumer._handle_message(
+                self._make_candle_msg(instrument="XAUUSD", timeframe="H1", complete=True, idx=i)
+            )
+        assert "EURUSD:M5" in consumer._windows
+        assert "XAUUSD:H1" in consumer._windows
+        assert len(consumer._windows["EURUSD:M5"]) == 3
+        assert len(consumer._windows["XAUUSD:H1"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_candle_missing_instrument_skipped(self):
+        """Candles without instrument field are skipped."""
+        consumer = self._make_consumer()
+        msg = self._make_candle_msg(complete=True)
+        del msg["instrument"]
+        await consumer._handle_message(msg)
+        consumer.engine.predict.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_candle_missing_timeframe_skipped(self):
+        """Candles without timeframe field are skipped."""
+        consumer = self._make_consumer()
+        msg = self._make_candle_msg(complete=True)
+        del msg["timeframe"]
+        await consumer._handle_message(msg)
+        consumer.engine.predict.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_low_confidence_setup_not_published(self):
+        """Setups with confidence < CONFIDENCE_FLOOR are not published."""
+        consumer = self._make_consumer()
+        # Engine returns 0.0 confidence (stub)
+        for i in range(3):
+            await consumer._handle_message(self._make_candle_msg(complete=True, idx=i))
+        consumer.publisher.publish.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_high_confidence_setup_published(self):
+        """Setups with confidence >= CONFIDENCE_LOG_ONLY (0.75) are published."""
+        consumer = self._make_consumer()
+        # Override engine to return high confidence
+        consumer.engine.predict = Mock(return_value={
+            "time": "2024-01-01T00:00:00Z",
+            "regime": "TRENDING_BULLISH",
+            "patterns": ["BOS_CONFIRMED"],
+            "confidence_score": 0.82,
+            "htf_projections": {
+                "htf_timeframe": "H1",
+                "htf_open": 1.1000,
+                "htf_high": 1.1200,
+                "htf_low": 1.0800,
+                "open_bias": "BULLISH",
+                "htf_high_proximity_pct": 30.0,
+                "htf_low_proximity_pct": 70.0,
+                "htf_body_pct": 60.0,
+                "htf_upper_wick_pct": 20.0,
+                "htf_lower_wick_pct": 20.0,
+                "htf_close_position": 0.8,
+            },
+            "entry_price": 1.1050,
+            "sl_price": 1.0800,
+            "tp_price": 1.1200,
+        })
+        for i in range(3):
+            await consumer._handle_message(self._make_candle_msg(complete=True, idx=i))
+        consumer.publisher.publish.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_log_only_confidence_not_published(self):
+        """Setups with 0.65 <= confidence < 0.75 are logged but not published."""
+        consumer = self._make_consumer()
+        consumer.engine.predict = Mock(return_value={
+            "time": "2024-01-01T00:00:00Z",
+            "regime": "RANGING",
+            "patterns": [],
+            "confidence_score": 0.70,  # log-only range
+            "htf_projections": {
+                "htf_timeframe": "H1",
+                "htf_open": 1.1000,
+                "htf_high": 1.1200,
+                "htf_low": 1.0800,
+                "open_bias": "NEUTRAL",
+                "htf_high_proximity_pct": 50.0,
+                "htf_low_proximity_pct": 50.0,
+                "htf_body_pct": 60.0,
+                "htf_upper_wick_pct": 20.0,
+                "htf_lower_wick_pct": 20.0,
+                "htf_close_position": 0.5,
+            },
+            "entry_price": None,
+            "sl_price": None,
+            "tp_price": None,
+        })
+        for i in range(3):
+            await consumer._handle_message(self._make_candle_msg(complete=True, idx=i))
+        consumer.publisher.publish.assert_not_called()
+
+
+# ===========================================================================
+# 9. SetupPublisher tests
+# ===========================================================================
+
+
+class TestSetupPublisher:
+    """Tests for SetupPublisher Kafka producer."""
+
+    @pytest.mark.asyncio
+    async def test_publisher_instantiates(self):
+        """SetupPublisher can be instantiated with bootstrap_servers."""
+        publisher = SetupPublisher(bootstrap_servers="localhost:9092")
+        assert publisher is not None
+
+    @pytest.mark.asyncio
+    async def test_publisher_start_creates_producer(self):
+        """start() creates an AIOKafkaProducer instance."""
+        with patch("ml.inference.main.AIOKafkaProducer") as mock_producer_cls:
+            mock_producer = AsyncMock()
+            mock_producer_cls.return_value = mock_producer
+            publisher = SetupPublisher(bootstrap_servers="localhost:9092")
+            await publisher.start()
+            mock_producer.start.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_publisher_stop_flushes_and_stops(self):
+        """stop() flushes pending messages and stops the producer."""
+        with patch("ml.inference.main.AIOKafkaProducer") as mock_producer_cls:
+            mock_producer = AsyncMock()
+            mock_producer_cls.return_value = mock_producer
+            publisher = SetupPublisher(bootstrap_servers="localhost:9092")
+            await publisher.start()
+            await publisher.stop()
+            mock_producer.flush.assert_called_once()
+            mock_producer.stop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_publisher_publish_sends_to_setups_topic(self):
+        """publish() sends message to setups.detected topic."""
+        with patch("ml.inference.main.AIOKafkaProducer") as mock_producer_cls:
+            mock_producer = AsyncMock()
+            mock_producer_cls.return_value = mock_producer
+            publisher = SetupPublisher(bootstrap_servers="localhost:9092")
+            await publisher.start()
+
+            setup = {
+                "instrument": "EURUSD",
+                "timeframe": "M5",
+                "time": "2024-01-01T10:00:00Z",
+                "regime": "TRENDING_BULLISH",
+                "patterns": ["BOS_CONFIRMED"],
+                "confidence_score": 0.82,
+                "htf_open": 1.1000,
+                "htf_high": 1.1200,
+                "htf_low": 1.0800,
+                "open_bias": "BULLISH",
+                "entry_price": 1.1050,
+                "sl_price": 1.0800,
+                "tp_price": 1.1200,
+            }
+            await publisher.publish(setup)
+
+            mock_producer.send.assert_called_once()
+            call_args = mock_producer.send.call_args
+            assert call_args[0][0] == TOPIC_SETUPS
+            assert call_args[1]["key"] == b"EURUSD:M5"
+
+    @pytest.mark.asyncio
+    async def test_publisher_publish_json_encodes_message(self):
+        """publish() JSON-encodes the setup message."""
+        with patch("ml.inference.main.AIOKafkaProducer") as mock_producer_cls:
+            mock_producer = AsyncMock()
+            mock_producer_cls.return_value = mock_producer
+            publisher = SetupPublisher(bootstrap_servers="localhost:9092")
+            await publisher.start()
+
+            setup = {
+                "instrument": "XAUUSD",
+                "timeframe": "H1",
+                "time": "2024-01-01T10:00:00Z",
+                "regime": "BREAKOUT",
+                "patterns": [],
+                "confidence_score": 0.78,
+                "htf_open": 2380.0,
+                "htf_high": 2400.0,
+                "htf_low": 2360.0,
+                "open_bias": "BULLISH",
+                "entry_price": 2385.0,
+                "sl_price": 2360.0,
+                "tp_price": 2400.0,
+            }
+            await publisher.publish(setup)
+
+            call_args = mock_producer.send.call_args
+            value_bytes = call_args[1]["value"]
+            decoded = json.loads(value_bytes.decode())
+            assert decoded["instrument"] == "XAUUSD"
+            assert decoded["confidence_score"] == 0.78
+
+
+# ===========================================================================
+# 10. Integration test: full app lifecycle
+# ===========================================================================
+
+
+class TestAppLifecycle:
+    """Integration tests for the full FastAPI app lifecycle."""
+
+    def test_app_starts_and_stops_cleanly(self, stub_registry):
+        """App lifespan starts and stops without errors."""
+        app = create_app(registry=stub_registry)
+        # Simulate lifespan startup and shutdown
+        with TestClient(app) as client:
+            response = client.get("/health")
+            assert response.status_code == 200
+
+    def test_app_loads_models_on_startup(self, stub_registry):
+        """App calls registry.load() during startup."""
+        with patch.object(ModelRegistry, "load") as mock_load:
+            app = create_app(registry=stub_registry)
+            with TestClient(app):
+                pass
+            # load() should have been called during lifespan startup
+            # (already called in fixture, so we just verify registry is loaded)
+            assert stub_registry.loaded is True
+
+    def test_app_exposes_predict_endpoint(self, test_client):
+        """App exposes POST /predict endpoint."""
+        response = test_client.post(
+            "/predict",
+            json={
+                "instrument": "EURUSD",
+                "timeframe": "M5",
+                "candles": _make_candles(5),
+            },
+        )
+        assert response.status_code == 200
+
+    def test_app_exposes_health_endpoint(self, test_client):
+        """App exposes GET /health endpoint."""
+        response = test_client.get("/health")
+        assert response.status_code == 200
+
+    def test_app_title_and_version(self, stub_registry):
+        """App has correct title and version."""
+        app = create_app(registry=stub_registry)
+        assert "AgentICTrader" in app.title
+        assert app.version == "1.0.0"
+
+
+# ===========================================================================
+# 11. Error handling tests
+# ===========================================================================
+
+
+class TestErrorHandling:
+    """Tests for error handling in the inference service."""
+
+    @pytest.fixture
+    def client(self, stub_registry) -> TestClient:
+        app = create_app(registry=stub_registry)
+        return TestClient(app)
+
+    def test_predict_invalid_json_returns_422(self, client):
+        """POST /predict with invalid JSON returns 422."""
+        response = client.post("/predict", data="not json")
+        assert response.status_code == 422
+
+    def test_predict_missing_required_field_returns_422(self, client):
+        """POST /predict missing required field returns 422."""
+        response = client.post(
+            "/predict",
+            json={"instrument": "EURUSD"},  # missing timeframe and candles
+        )
+        assert response.status_code == 422
+
+    def test_predict_invalid_candle_schema_returns_422(self, client):
+        """POST /predict with invalid candle schema returns 422."""
+        response = client.post(
+            "/predict",
+            json={
+                "instrument": "EURUSD",
+                "timeframe": "M5",
+                "candles": [{"invalid": "schema"}],
+            },
+        )
+        assert response.status_code == 422
+
+    def test_predict_engine_exception_returns_500(self, stub_registry):
+        """POST /predict returns 500 when InferenceEngine raises exception."""
+        with patch.object(InferenceEngine, "predict", side_effect=RuntimeError("Test error")):
+            app = create_app(registry=stub_registry)
+            client = TestClient(app)
+            response = client.post(
+                "/predict",
+                json={
+                    "instrument": "EURUSD",
+                    "timeframe": "M5",
+                    "candles": _make_candles(5),
+                },
+            )
+            assert response.status_code == 500
+            assert "Inference failed" in response.json()["detail"]
+
+
+# ===========================================================================
+# 12. Performance and latency tests
+# ===========================================================================
+
+
+class TestPerformance:
+    """Performance and latency tests for the inference service."""
+
+    @pytest.mark.slow
+    def test_predict_latency_under_500ms(self, test_client):
+        """POST /predict completes in < 500ms (NFR-1 requirement)."""
+        import time
+
+        payload = {
+            "instrument": "EURUSD",
+            "timeframe": "M5",
+            "candles": _make_candles(50),
+        }
+        start = time.time()
+        response = test_client.post("/predict", json=payload)
+        elapsed = time.time() - start
+
+        assert response.status_code == 200
+        assert elapsed < 0.5, f"Predict took {elapsed:.3f}s (> 500ms)"
+
+    @pytest.mark.slow
+    def test_health_latency_under_100ms(self, test_client):
+        """GET /health completes in < 100ms."""
+        import time
+
+        start = time.time()
+        response = test_client.get("/health")
+        elapsed = time.time() - start
+
+        assert response.status_code == 200
+        assert elapsed < 0.1, f"Health check took {elapsed:.3f}s (> 100ms)"
+
+
+
+

--- a/ml/inference/__init__.py
+++ b/ml/inference/__init__.py
@@ -1,0 +1,1 @@
+"""ML inference service package."""

--- a/ml/inference/main.py
+++ b/ml/inference/main.py
@@ -1,0 +1,832 @@
+"""
+ML Inference FastAPI Service.
+
+Loads trained models from the MLflow registry and exposes:
+  POST /predict  — synchronous inference for a single instrument/timeframe/candles payload
+  GET  /health   — liveness check
+
+Also runs a background Kafka consumer that:
+  - Consumes completed candles from market.candles
+  - Runs the full inference pipeline (feature extraction → regime → patterns → confluence)
+  - Publishes detected setups to setups.detected
+
+setups.detected message schema:
+  {
+    instrument, timeframe, time, regime, patterns, confidence_score,
+    htf_open, htf_high, htf_low, open_bias,
+    entry_price, sl_price, tp_price
+  }
+
+Confidence thresholds (from design.md):
+  < 0.65  → DISCARD (not published)
+  0.65–0.74 → LOG ONLY (not published)
+  ≥ 0.75  → publish to setups.detected
+
+Usage:
+    uvicorn ml.inference.main:app --host 0.0.0.0 --port 8001
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from contextlib import asynccontextmanager
+from dataclasses import asdict
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import mlflow
+import mlflow.sklearn
+import numpy as np
+from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Path setup — allow running from project root
+# ---------------------------------------------------------------------------
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from ml.features.pipeline import FeaturePipeline
+from ml.features.htf_selector import get_htf_correlation, TradingStyle
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(name)s  %(levelname)s  %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+TOPIC_CANDLES = "market.candles"
+TOPIC_SETUPS = "setups.detected"
+
+CONFIDENCE_FLOOR = 0.65    # below this → discard
+CONFIDENCE_LOG_ONLY = 0.75  # [0.65, 0.75) → log only, not published
+
+REGIME_CLASSES = [
+    "TRENDING_BULLISH",
+    "TRENDING_BEARISH",
+    "RANGING",
+    "BREAKOUT",
+    "NEWS_DRIVEN",
+]
+
+PATTERN_LABELS = [
+    "BOS_CONFIRMED",
+    "CHOCH_DETECTED",
+    "BEARISH_ARRAY_REJECTION",
+    "BULLISH_ARRAY_BOUNCE",
+    "FVG_PRESENT",
+    "LIQUIDITY_SWEEP",
+    "ORDER_BLOCK",
+    "INDUCEMENT",
+]
+
+# ---------------------------------------------------------------------------
+# Pydantic schemas
+# ---------------------------------------------------------------------------
+
+
+class OHLCVCandle(BaseModel):
+    """Single OHLCV candle."""
+
+    time: str = Field(..., description="ISO-8601 UTC timestamp")
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float = 0.0
+
+
+class PredictRequest(BaseModel):
+    """Request body for POST /predict."""
+
+    instrument: str = Field(..., description="e.g. EURUSD, XAUUSD, US500")
+    timeframe: str = Field(..., description="e.g. M1, M5, M15, H1, H4, D1")
+    candles: List[OHLCVCandle] = Field(
+        ..., min_length=2, description="Chronological list of OHLCV candles"
+    )
+    # Optional reference prices for session feature computation
+    daily_open: Optional[float] = None
+    weekly_open: Optional[float] = None
+    true_day_open: Optional[float] = None
+
+
+class HTFProjections(BaseModel):
+    """HTF projection levels returned in the predict response."""
+
+    htf_timeframe: str
+    htf_open: float
+    htf_high: float
+    htf_low: float
+    open_bias: str  # BULLISH | BEARISH | NEUTRAL
+    htf_high_proximity_pct: float
+    htf_low_proximity_pct: float
+    htf_body_pct: float
+    htf_upper_wick_pct: float
+    htf_lower_wick_pct: float
+    htf_close_position: float
+
+
+class PredictResponse(BaseModel):
+    """Response body for POST /predict."""
+
+    instrument: str
+    timeframe: str
+    time: str
+    regime: str
+    patterns: List[str]
+    confidence_score: float
+    htf_projections: HTFProjections
+    # Derived trade levels (None when confidence < floor)
+    entry_price: Optional[float] = None
+    sl_price: Optional[float] = None
+    tp_price: Optional[float] = None
+
+
+class HealthResponse(BaseModel):
+    """Response body for GET /health."""
+
+    status: str
+    models_loaded: bool
+    kafka_consumer_running: bool
+
+
+# ---------------------------------------------------------------------------
+# Model registry loader
+# ---------------------------------------------------------------------------
+
+
+class ModelRegistry:
+    """
+    Loads and caches the three trained models from the MLflow registry.
+
+    Falls back to stub predictors when models are not yet registered
+    (e.g. during development before training is complete).
+    """
+
+    def __init__(self, tracking_uri: Optional[str] = None) -> None:
+        self.tracking_uri = tracking_uri or os.getenv(
+            "MLFLOW_TRACKING_URI", "http://localhost:5000"
+        )
+        mlflow.set_tracking_uri(self.tracking_uri)
+
+        self._regime_model: Any = None
+        self._pattern_model: Any = None
+        self._confluence_model: Any = None
+        self._loaded = False
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def load(self) -> None:
+        """Load all three models from the MLflow registry."""
+        self._regime_model = self._load_model("regime-classifier")
+        self._pattern_model = self._load_model("pattern-detector")
+        self._confluence_model = self._load_model("confluence-scorer")
+        self._loaded = True
+        logger.info("All models loaded (or stubs installed)")
+
+    @property
+    def loaded(self) -> bool:
+        return self._loaded
+
+    def predict_regime(self, X: np.ndarray) -> str:
+        """Return the predicted regime class label."""
+        if self._regime_model is None:
+            return "RANGING"  # stub default
+        raw = self._regime_model.predict(X)
+        idx = int(raw[0])
+        if 0 <= idx < len(REGIME_CLASSES):
+            return REGIME_CLASSES[idx]
+        # Model may return string labels directly
+        return str(raw[0])
+
+    def predict_patterns(self, X: np.ndarray, threshold: float = 0.5) -> List[str]:
+        """Return list of active pattern labels above threshold."""
+        if self._pattern_model is None:
+            return []  # stub default
+        try:
+            proba_list = self._pattern_model.predict_proba(X)
+            active = []
+            for label_idx, proba in enumerate(proba_list):
+                if proba[0, 1] >= threshold:
+                    active.append(PATTERN_LABELS[label_idx])
+            return active
+        except AttributeError:
+            # Model doesn't support predict_proba — fall back to predict
+            raw = self._pattern_model.predict(X)
+            return [
+                PATTERN_LABELS[i]
+                for i, val in enumerate(raw[0])
+                if val == 1 and i < len(PATTERN_LABELS)
+            ]
+
+    def predict_confidence(self, X: np.ndarray) -> float:
+        """Return calibrated confidence score in [0.0, 1.0]."""
+        if self._confluence_model is None:
+            return 0.0  # stub default
+        proba = self._confluence_model.predict_proba(X)
+        return float(proba[0, 1])
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _load_model(self, model_name: str) -> Optional[Any]:
+        """
+        Attempt to load the latest Production version of a registered model.
+
+        Returns None (stub) if the model is not yet registered.
+        """
+        try:
+            client = mlflow.tracking.MlflowClient()
+            versions = client.get_latest_versions(model_name, stages=["Production"])
+            if not versions:
+                # Fall back to any registered version
+                versions = client.get_latest_versions(model_name)
+            if not versions:
+                logger.warning(
+                    "Model '%s' not found in registry — using stub predictor", model_name
+                )
+                return None
+            model_uri = f"models:/{model_name}/{versions[0].version}"
+            model = mlflow.sklearn.load_model(model_uri)
+            logger.info("Loaded model '%s' version %s", model_name, versions[0].version)
+            return model
+        except Exception as exc:
+            logger.warning(
+                "Could not load model '%s': %s — using stub predictor", model_name, exc
+            )
+            return None
+
+
+# ---------------------------------------------------------------------------
+# Inference engine
+# ---------------------------------------------------------------------------
+
+
+class InferenceEngine:
+    """
+    Orchestrates feature extraction and model inference for a single setup.
+
+    Accepts a list of OHLCV candles, extracts features via FeaturePipeline,
+    runs the three models, and returns a structured prediction.
+    """
+
+    def __init__(self, registry: ModelRegistry) -> None:
+        self.registry = registry
+        self.pipeline = FeaturePipeline(enable_validation=False)
+
+    def predict(
+        self,
+        instrument: str,
+        timeframe: str,
+        candles: List[Dict[str, Any]],
+        daily_open: Optional[float] = None,
+        weekly_open: Optional[float] = None,
+        true_day_open: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """
+        Run full inference pipeline for a single instrument/timeframe/candles payload.
+
+        Args:
+            instrument: Trading instrument (e.g. "EURUSD")
+            timeframe: Candle timeframe (e.g. "M5")
+            candles: Chronological list of OHLCV dicts
+            daily_open: Optional daily open reference price
+            weekly_open: Optional weekly open reference price
+            true_day_open: Optional true day open reference price
+
+        Returns:
+            Dict with keys: regime, patterns, confidence_score, htf_projections,
+                            entry_price, sl_price, tp_price, time
+        """
+        if len(candles) < 2:
+            raise ValueError("At least 2 candles are required for inference")
+
+        # Determine HTF timeframe using the 3-tier correlation
+        htf_timeframe = self._get_htf_timeframe(timeframe)
+
+        # Use the most recent candle as the HTF candle proxy when no separate
+        # HTF feed is available (the pipeline will use it for HTF projections)
+        htf_candle = self._build_htf_candle(candles, htf_timeframe)
+
+        # Extract features
+        features_df = self.pipeline.transform(
+            candles=candles,
+            htf_candle=htf_candle,
+            instrument=instrument,
+            htf_timeframe=htf_timeframe,
+            daily_open=daily_open,
+            weekly_open=weekly_open,
+            true_day_open=true_day_open,
+        )
+
+        # Encode for sklearn models
+        X = self._encode_features(features_df)
+
+        # Run models
+        regime = self.registry.predict_regime(X)
+        patterns = self.registry.predict_patterns(X)
+        confidence_score = self.registry.predict_confidence(X)
+
+        # Extract HTF projection values from features
+        htf_proj = self._extract_htf_projections(features_df, htf_timeframe)
+
+        # Derive trade levels from the last candle and HTF levels
+        current_candle = candles[-1]
+        entry_price, sl_price, tp_price = self._derive_trade_levels(
+            current_candle=current_candle,
+            htf_proj=htf_proj,
+            confidence_score=confidence_score,
+        )
+
+        # Timestamp from the most recent candle
+        time_str = str(current_candle.get("time", datetime.now(timezone.utc).isoformat()))
+
+        return {
+            "time": time_str,
+            "regime": regime,
+            "patterns": patterns,
+            "confidence_score": confidence_score,
+            "htf_projections": htf_proj,
+            "entry_price": entry_price,
+            "sl_price": sl_price,
+            "tp_price": tp_price,
+        }
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _get_htf_timeframe(self, timeframe: str) -> str:
+        """Derive the HTF timeframe using the INTRADAY_STANDARD 3-tier correlation."""
+        try:
+            bias_tf, structure_tf, entry_tf = get_htf_correlation(
+                timeframe, TradingStyle.INTRADAY_STANDARD
+            )
+            return bias_tf
+        except (ValueError, KeyError):
+            # Fallback mapping for timeframes not in the selector
+            _fallback = {
+                "M1": "M5", "M3": "M15", "M5": "M15",
+                "M15": "H1", "M30": "H4", "H1": "H4",
+                "H4": "D1", "D1": "W1", "W1": "D1",
+            }
+            return _fallback.get(timeframe, "H1")
+
+    def _build_htf_candle(
+        self, candles: List[Dict[str, Any]], htf_timeframe: str
+    ) -> Dict[str, Any]:
+        """
+        Build a synthetic HTF candle from the provided candle list.
+
+        In production the HTF candle would be fetched from TimescaleDB.
+        Here we aggregate the provided candles into a single OHLCV candle
+        to represent the HTF period.
+        """
+        opens = [float(c["open"]) for c in candles]
+        highs = [float(c["high"]) for c in candles]
+        lows = [float(c["low"]) for c in candles]
+        closes = [float(c["close"]) for c in candles]
+        volumes = [float(c.get("volume", 0)) for c in candles]
+
+        return {
+            "time": candles[0]["time"],
+            "open": opens[0],
+            "high": max(highs),
+            "low": min(lows),
+            "close": closes[-1],
+            "volume": sum(volumes),
+        }
+
+    def _encode_features(self, features_df) -> np.ndarray:
+        """Encode the feature DataFrame to a numeric numpy array for sklearn."""
+        import pandas as pd
+
+        df = features_df.copy()
+
+        # Encode string/bool columns
+        bias_map = {"BULLISH": 1, "NEUTRAL": 0, "BEARISH": -1}
+        pos_map = {"ABOVE": 1, "AT": 0, "BELOW": -1}
+
+        for col in df.columns:
+            if df[col].dtype == bool:
+                df[col] = df[col].astype(int)
+            elif col in ("htf_open_bias", "htf_trend_bias"):
+                df[col] = df[col].map(bias_map).fillna(0)
+            elif col in ("price_vs_daily_open", "price_vs_weekly_open", "price_vs_true_day_open"):
+                df[col] = df[col].map(pos_map).fillna(0)
+            elif df[col].dtype == object:
+                df[col] = pd.Categorical(df[col]).codes
+
+        return df.values.astype(float)
+
+    def _extract_htf_projections(
+        self, features_df, htf_timeframe: str
+    ) -> Dict[str, Any]:
+        """Extract HTF projection values from the feature DataFrame."""
+        row = features_df.iloc[0]
+        return {
+            "htf_timeframe": htf_timeframe,
+            "htf_open": float(row.get("htf_open", 0.0)),
+            "htf_high": float(row.get("htf_high", 0.0)),
+            "htf_low": float(row.get("htf_low", 0.0)),
+            "open_bias": str(row.get("htf_open_bias", "NEUTRAL")),
+            "htf_high_proximity_pct": float(row.get("htf_high_proximity_pct", 50.0)),
+            "htf_low_proximity_pct": float(row.get("htf_low_proximity_pct", 50.0)),
+            "htf_body_pct": float(row.get("htf_body_pct", 0.0)),
+            "htf_upper_wick_pct": float(row.get("htf_upper_wick_pct", 0.0)),
+            "htf_lower_wick_pct": float(row.get("htf_lower_wick_pct", 0.0)),
+            "htf_close_position": float(row.get("htf_close_position", 50.0)),
+        }
+
+    def _derive_trade_levels(
+        self,
+        current_candle: Dict[str, Any],
+        htf_proj: Dict[str, Any],
+        confidence_score: float,
+    ) -> tuple[Optional[float], Optional[float], Optional[float]]:
+        """
+        Derive entry, SL, and TP prices from the current candle and HTF levels.
+
+        Returns (None, None, None) when confidence is below the floor.
+
+        Logic:
+          - Bullish: entry = current close, SL = HTF low, TP = HTF high
+          - Bearish: entry = current close, SL = HTF high, TP = HTF low
+          - Neutral: no trade levels
+        """
+        if confidence_score < CONFIDENCE_FLOOR:
+            return None, None, None
+
+        close = float(current_candle["close"])
+        htf_high = htf_proj["htf_high"]
+        htf_low = htf_proj["htf_low"]
+        open_bias = htf_proj["open_bias"]
+
+        if open_bias == "BULLISH":
+            entry_price = close
+            sl_price = htf_low
+            tp_price = htf_high
+        elif open_bias == "BEARISH":
+            entry_price = close
+            sl_price = htf_high
+            tp_price = htf_low
+        else:
+            return None, None, None
+
+        # Sanity check: SL must differ from entry
+        if abs(entry_price - sl_price) < 1e-8:
+            return None, None, None
+
+        return entry_price, sl_price, tp_price
+
+
+# ---------------------------------------------------------------------------
+# Kafka consumer
+# ---------------------------------------------------------------------------
+
+
+class SetupPublisher:
+    """Publishes detected setups to the setups.detected Kafka topic."""
+
+    def __init__(self, bootstrap_servers: str) -> None:
+        self.bootstrap_servers = bootstrap_servers
+        self._producer: Optional[AIOKafkaProducer] = None
+
+    async def start(self) -> None:
+        self._producer = AIOKafkaProducer(bootstrap_servers=self.bootstrap_servers)
+        await self._producer.start()
+
+    async def stop(self) -> None:
+        if self._producer:
+            await self._producer.flush()
+            await self._producer.stop()
+
+    async def publish(self, setup: Dict[str, Any]) -> None:
+        if self._producer is None:
+            return
+        key = f"{setup['instrument']}:{setup['timeframe']}".encode()
+        value = json.dumps(setup, default=str).encode()
+        await self._producer.send(TOPIC_SETUPS, key=key, value=value)
+
+
+class CandleConsumer:
+    """
+    Kafka consumer that reads from market.candles and runs inference.
+
+    For each completed candle:
+      1. Accumulate a rolling window of candles per instrument/timeframe
+      2. Run InferenceEngine.predict()
+      3. If confidence >= 0.75, publish to setups.detected
+    """
+
+    # Rolling window size per instrument:timeframe key
+    WINDOW_SIZE = 50
+
+    def __init__(
+        self,
+        bootstrap_servers: str,
+        engine: InferenceEngine,
+        publisher: SetupPublisher,
+        group_id: str = "ml-inference-service",
+    ) -> None:
+        self.bootstrap_servers = bootstrap_servers
+        self.engine = engine
+        self.publisher = publisher
+        self.group_id = group_id
+        self._consumer: Optional[AIOKafkaConsumer] = None
+        self._running = False
+        # Rolling candle windows: key = "instrument:timeframe"
+        self._windows: Dict[str, List[Dict[str, Any]]] = {}
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    async def start(self) -> None:
+        self._consumer = AIOKafkaConsumer(
+            TOPIC_CANDLES,
+            bootstrap_servers=self.bootstrap_servers,
+            group_id=self.group_id,
+            value_deserializer=lambda v: json.loads(v.decode()),
+            auto_offset_reset="latest",
+        )
+        await self._consumer.start()
+        self._running = True
+        logger.info("Kafka consumer started — listening on %s", TOPIC_CANDLES)
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._consumer:
+            await self._consumer.stop()
+
+    async def run(self) -> None:
+        """Main consume loop — runs until stop() is called."""
+        if self._consumer is None:
+            raise RuntimeError("Consumer not started — call start() first")
+
+        async for msg in self._consumer:
+            if not self._running:
+                break
+            try:
+                await self._handle_message(msg.value)
+            except Exception as exc:
+                logger.error("Error handling candle message: %s", exc, exc_info=True)
+
+    async def _handle_message(self, candle: Dict[str, Any]) -> None:
+        """Process a single candle message."""
+        # Only process completed candles
+        if not candle.get("complete", False):
+            return
+
+        instrument = candle.get("instrument", "")
+        timeframe = candle.get("timeframe", "")
+        if not instrument or not timeframe:
+            return
+
+        key = f"{instrument}:{timeframe}"
+
+        # Maintain rolling window
+        window = self._windows.setdefault(key, [])
+        window.append(candle)
+        if len(window) > self.WINDOW_SIZE:
+            window.pop(0)
+
+        # Need at least 2 candles for inference
+        if len(window) < 2:
+            return
+
+        # Run inference
+        result = self.engine.predict(
+            instrument=instrument,
+            timeframe=timeframe,
+            candles=window,
+        )
+
+        confidence = result["confidence_score"]
+
+        if confidence < CONFIDENCE_FLOOR:
+            logger.debug(
+                "Setup discarded (confidence=%.3f < %.2f): %s %s",
+                confidence, CONFIDENCE_FLOOR, instrument, timeframe,
+            )
+            return
+
+        if confidence < CONFIDENCE_LOG_ONLY:
+            logger.info(
+                "Setup logged only (confidence=%.3f): %s %s — regime=%s patterns=%s",
+                confidence, instrument, timeframe, result["regime"], result["patterns"],
+            )
+            return
+
+        # Build setups.detected message
+        htf = result["htf_projections"]
+        setup_msg: Dict[str, Any] = {
+            "instrument": instrument,
+            "timeframe": timeframe,
+            "time": result["time"],
+            "regime": result["regime"],
+            "patterns": result["patterns"],
+            "confidence_score": confidence,
+            "htf_open": htf["htf_open"],
+            "htf_high": htf["htf_high"],
+            "htf_low": htf["htf_low"],
+            "open_bias": htf["open_bias"],
+            "entry_price": result["entry_price"],
+            "sl_price": result["sl_price"],
+            "tp_price": result["tp_price"],
+        }
+
+        await self.publisher.publish(setup_msg)
+        logger.info(
+            "Setup published (confidence=%.3f): %s %s regime=%s patterns=%s",
+            confidence, instrument, timeframe, result["regime"], result["patterns"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Application factory
+# ---------------------------------------------------------------------------
+
+
+def create_app(
+    registry: Optional[ModelRegistry] = None,
+    consumer: Optional[CandleConsumer] = None,
+    skip_kafka: bool = False,
+) -> FastAPI:
+    """
+    Create and configure the FastAPI application.
+
+    Args:
+        registry: Pre-built ModelRegistry (injected for testing)
+        consumer: Pre-built CandleConsumer (injected for testing)
+        skip_kafka: When True, skip Kafka consumer/producer startup entirely.
+                    Automatically set to True when a registry is injected (test mode).
+
+    Returns:
+        Configured FastAPI application
+    """
+    _registry = registry or ModelRegistry()
+    _consumer_ref: Dict[str, Any] = {"instance": consumer}
+    _consumer_task: Dict[str, Any] = {"task": None}
+    # Skip Kafka when a registry is injected (test mode) or explicitly requested
+    _skip_kafka = skip_kafka or (registry is not None and consumer is None)
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        # Startup — only load models if not already loaded (e.g. injected in tests)
+        if not _registry.loaded:
+            _registry.load()
+
+        bootstrap = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+
+        if not _skip_kafka and _consumer_ref["instance"] is None:
+            engine = InferenceEngine(_registry)
+            publisher = SetupPublisher(bootstrap)
+            try:
+                await asyncio.wait_for(publisher.start(), timeout=5.0)
+            except (Exception, asyncio.TimeoutError) as exc:
+                logger.warning("Kafka publisher unavailable: %s", exc)
+
+            _consumer_ref["instance"] = CandleConsumer(
+                bootstrap_servers=bootstrap,
+                engine=engine,
+                publisher=publisher,
+            )
+            try:
+                await asyncio.wait_for(_consumer_ref["instance"].start(), timeout=5.0)
+                _consumer_task["task"] = asyncio.create_task(
+                    _consumer_ref["instance"].run()
+                )
+            except (Exception, asyncio.TimeoutError) as exc:
+                logger.warning("Kafka consumer unavailable: %s", exc)
+
+        yield
+
+        # Shutdown
+        if _consumer_task["task"]:
+            _consumer_task["task"].cancel()
+            try:
+                await _consumer_task["task"]
+            except asyncio.CancelledError:
+                pass
+        if _consumer_ref["instance"]:
+            try:
+                await _consumer_ref["instance"].stop()
+            except Exception:
+                pass
+
+    app = FastAPI(
+        title="AgentICTrader ML Inference Service",
+        description=(
+            "Loads regime-classifier, pattern-detector, and confluence-scorer "
+            "from MLflow and exposes a /predict endpoint. Also consumes "
+            "market.candles and publishes to setups.detected."
+        ),
+        version="1.0.0",
+        lifespan=lifespan,
+    )
+
+    # ------------------------------------------------------------------
+    # Routes
+    # ------------------------------------------------------------------
+
+    @app.get("/health", response_model=HealthResponse)
+    async def health() -> HealthResponse:
+        """Liveness check."""
+        consumer_running = (
+            _consumer_ref["instance"] is not None
+            and _consumer_ref["instance"].running
+        )
+        return HealthResponse(
+            status="ok",
+            models_loaded=_registry.loaded,
+            kafka_consumer_running=consumer_running,
+        )
+
+    @app.post("/predict", response_model=PredictResponse)
+    async def predict(request: PredictRequest) -> PredictResponse:
+        """
+        Run ML inference for a given instrument/timeframe/candles payload.
+
+        Returns regime classification, detected patterns, confidence score,
+        HTF projection levels, and derived trade levels.
+        """
+        if len(request.candles) < 2:
+            raise HTTPException(
+                status_code=422,
+                detail="At least 2 candles are required for inference",
+            )
+
+        candles_dicts = [c.model_dump() for c in request.candles]
+
+        engine = InferenceEngine(_registry)
+        try:
+            result = engine.predict(
+                instrument=request.instrument,
+                timeframe=request.timeframe,
+                candles=candles_dicts,
+                daily_open=request.daily_open,
+                weekly_open=request.weekly_open,
+                true_day_open=request.true_day_open,
+            )
+        except Exception as exc:
+            logger.error("Inference error: %s", exc, exc_info=True)
+            raise HTTPException(status_code=500, detail=f"Inference failed: {exc}")
+
+        htf = result["htf_projections"]
+        return PredictResponse(
+            instrument=request.instrument,
+            timeframe=request.timeframe,
+            time=result["time"],
+            regime=result["regime"],
+            patterns=result["patterns"],
+            confidence_score=result["confidence_score"],
+            htf_projections=HTFProjections(
+                htf_timeframe=htf["htf_timeframe"],
+                htf_open=htf["htf_open"],
+                htf_high=htf["htf_high"],
+                htf_low=htf["htf_low"],
+                open_bias=htf["open_bias"],
+                htf_high_proximity_pct=htf["htf_high_proximity_pct"],
+                htf_low_proximity_pct=htf["htf_low_proximity_pct"],
+                htf_body_pct=htf["htf_body_pct"],
+                htf_upper_wick_pct=htf["htf_upper_wick_pct"],
+                htf_lower_wick_pct=htf["htf_lower_wick_pct"],
+                htf_close_position=htf["htf_close_position"],
+            ),
+            entry_price=result["entry_price"],
+            sl_price=result["sl_price"],
+            tp_price=result["tp_price"],
+        )
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+app = create_app()
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(
+        "ml.inference.main:app",
+        host="0.0.0.0",
+        port=int(os.getenv("INFERENCE_PORT", "8001")),
+        reload=False,
+    )


### PR DESCRIPTION
#  Build ML Inference FastAPI Service 

## Overview

Implements the ML inference service that bridges the trained models and the live trading pipeline. The service loads the three MLflow-registered models at startup and exposes them via a synchronous REST endpoint and an async Kafka consumer loop.

---

## Files Changed

| File | Change |
|---|---|
| `ml/inference/main.py` | New — full inference service implementation |
| `ml/inference/__init__.py` | New — package init |
| `backend/tests/test_inference_service.py` | New — 94 integration tests |
| `.kiro/specs/agentictrader-platform/tasks.md` | Updated — task 24 marked complete |

---

## What Was Built

### `ModelRegistry`

Loads `regime-classifier`, `pattern-detector`, and `confluence-scorer` from the MLflow model registry at startup. Falls back to safe stub predictors (`RANGING` / `[]` / `0.0`) when models are not yet registered, so the service stays operational during development.

### `InferenceEngine`

Orchestrates the full prediction pipeline:

1. Runs `FeaturePipeline.transform()` to extract HTF projection, candle structure, zone, and session features
2. Encodes the feature DataFrame for sklearn
3. Runs all three models in sequence
4. Derives `entry_price`, `sl_price`, and `tp_price` from HTF O/H/L levels and open bias

### `CandleConsumer`

Kafka consumer on `market.candles`. Maintains a 50-candle rolling window per `instrument:timeframe` key and triggers inference on every completed candle. Applies the three-tier confidence gate:

| Confidence | Action |
|---|---|
| `< 0.65` | Discard silently |
| `0.65 – 0.74` | Log only, do not publish |
| `>= 0.75` | Publish to `setups.detected` |

### `SetupPublisher`

Kafka producer that writes to `setups.detected` with the full 13-field schema:

```
instrument, timeframe, time, regime, patterns, confidence_score,
htf_open, htf_high, htf_low, open_bias,
entry_price, sl_price, tp_price
```

### `POST /predict`

Synchronous endpoint accepting `{instrument, timeframe, candles: list[OHLCV]}` with optional reference prices (`daily_open`, `weekly_open`, `true_day_open`). Returns the full prediction including HTF projections and trade levels.

### `GET /health`

Liveness check reporting `models_loaded` and `kafka_consumer_running` state.

---

## Bug Fixes — Lifespan Startup

Three issues were found and fixed that caused tests to hang indefinitely:

1. **MLflow connection hang** — `registry.load()` was called unconditionally in the lifespan, even when a pre-loaded registry was injected. Fixed with `if not registry.loaded` guard.

2. **Kafka startup hang (test mode)** — The lifespan tried to start real Kafka connections even when a registry was injected without a consumer. Fixed by auto-detecting test mode: when `registry` is injected and `consumer` is `None`, Kafka startup is skipped entirely via `skip_kafka=True`.

3. **Kafka startup hang (offline broker)** — `AIOKafkaProducer.start()` and `AIOKafkaConsumer.start()` block indefinitely when no broker is reachable. Fixed by wrapping both calls in `asyncio.wait_for(..., timeout=5.0)` so the service starts cleanly in environments where Kafka is temporarily offline.

---

## Test Coverage — `backend/tests/test_inference_service.py`

**94 tests, all passing in 6.45s**

| Test Class | Tests | Coverage |
|---|---|---|
| `TestConstants` | 8 | Topic names, threshold values, label lists |
| `TestModelRegistry` | 11 | Load, stub fallback, MLflow unavailable |
| `TestInferenceEngine` | 11 | `predict()` keys, types, HTF timeframe hierarchy |
| `TestPredictEndpoint` | 15 | HTTP 200/422, all 12 instruments, all timeframes |
| `TestHealthEndpoint` | 6 | Status, `models_loaded`, `kafka_consumer_running` |
| `TestConfidenceThresholds` | 7 | Floor gating, bullish/bearish/neutral trade levels |
| `TestSetupsDetectedSchema` | 10 | All 13 required fields, JSON serialisability |
| `TestCandleConsumer` | 10 | Rolling window, incomplete skip, publish gating |
| `TestSetupPublisher` | 5 | Kafka producer start/stop/publish |
| `TestAppLifecycle` | 5 | Lifespan, title, endpoint availability |
| `TestErrorHandling` | 4 | 422 on bad input, 500 on engine exception |
| `TestPerformance` | 2 | `POST /predict` < 500ms, `GET /health` < 100ms |

---

## Performance Results (NFR-1)

| Endpoint | Requirement | Result |
|---|---|---|
| `POST /predict` (50 candles) | < 500ms | ✅ Passed |
| `GET /health` | < 100ms | ✅ Passed |

---

## Commit

```
feat(task-24): Build ML inference FastAPI service

- Add ml/inference/main.py: FastAPI service with POST /predict and GET /health
- ModelRegistry: loads regime-classifier, pattern-detector, confluence-scorer
  from MLflow registry with graceful stub fallback when models unavailable
- InferenceEngine: orchestrates FeaturePipeline + 3 model predictions,
  derives entry/SL/TP from HTF projections and confidence score
- CandleConsumer: Kafka consumer on market.candles with 50-candle rolling
  window per instrument:timeframe, runs inference on each completed candle
- SetupPublisher: publishes to setups.detected when confidence >= 0.75
- Confidence gating: <0.65 discard, 0.65-0.74 log only, >=0.75 publish
- setups.detected schema: instrument, timeframe, time, regime, patterns,
  confidence_score, htf_open, htf_high, htf_low, open_bias, entry/sl/tp
- Fix lifespan: skip model load if already loaded (test mode), skip Kafka
  startup when registry injected without consumer, add asyncio.wait_for
  timeout on Kafka connections to prevent hanging in offline environments
- Add backend/tests/test_inference_service.py: 94 tests, all passing
  covering constants, ModelRegistry, InferenceEngine, /predict, /health,
  confidence thresholds, setups schema, CandleConsumer, SetupPublisher,
  app lifecycle, error handling, and latency (POST /predict < 500ms)
```

---

## Branch

`feature/zone-structure-extractor` → pushed to `origin` at commit `2f9fd2b`
