### PR TITLE
Feature/task 27 llm service

### DIFF
--- a/.kiro/specs/agentictrader-platform/tasks.md
+++ b/.kiro/specs/agentictrader-platform/tasks.md
@@ -341,7 +341,7 @@
 
 ## Phase 2 — Intelligence Layer
 
-- [ ] 25. Integrate news API and implement FinBERT sentiment classifier
+- [x] 25. Integrate news API and implement FinBERT sentiment classifier
   - Create services/nlp/sentiment_pipeline.py
   - Integrate news API (Alpha Vantage News or Reuters RSS)
   - Run FinBERT (ProsusAI/finbert from HuggingFace) on each article headline + summary
@@ -350,14 +350,14 @@
   - Cache latest score in Redis: key sentiment:{instrument}, TTL 900s
   - Write unit tests in backend/tests/test_sentiment_pipeline.py
 
-- [ ] 26. Implement economic calendar blackout monitor
+- [x] 26. Implement economic calendar blackout monitor
   - Create services/nlp/calendar_monitor.py
   - Poll TimescaleDB economic_events every 60s
   - Detect HIGH impact events within ±15 min window for each instrument's currency
   - Publish blackout state to Redis: key blackout:{instrument} → {active: bool, event_name, minutes_remaining}
   - Write unit tests in backend/tests/test_calendar_monitor.py
 
-- [ ] 27. Build LLM macro event summariser and trade reasoning generator
+- [x] 27. Build LLM macro event summariser and trade reasoning generator
   - Create services/nlp/llm_service.py
   - Implement summarise_macro_event(event: dict) → str using Claude API (anthropic SDK)
   - Implement generate_trade_reasoning(setup: dict) → str structured around the 3-question narrative framework:

--- a/.kiro/specs/agentictrader-platform/tasks.md
+++ b/.kiro/specs/agentictrader-platform/tasks.md
@@ -329,7 +329,7 @@
     - Confirm all tests PASS (GREEN)
   - **23c. REFACTOR** — clean up, confirm GREEN
 
-- [ ] 24. Build ML inference FastAPI service
+- [x] 24. Build ML inference FastAPI service
   - Create ml/inference/main.py using FastAPI
   - Load models from MLflow registry: regime-classifier, pattern-detector, confluence-scorer
   - Expose POST /predict endpoint: accepts {instrument, timeframe, candles: list[OHLCV]} → returns {regime, patterns, confidence_score, htf_projections}

--- a/backend/tests/test_calendar_monitor.py
+++ b/backend/tests/test_calendar_monitor.py
@@ -1,0 +1,474 @@
+"""
+Unit tests for services/nlp/calendar_monitor.py — Economic Calendar Blackout Monitor.
+
+TDD Phase: RED → GREEN → REFACTOR
+Run with: python -m pytest backend/tests/test_calendar_monitor.py -v --tb=short
+
+All tests use mocks — no real DB or Redis connections required.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Import targets — will raise ImportError until implementation is written
+# ---------------------------------------------------------------------------
+from services.nlp.calendar_monitor import (
+    CalendarMonitor,
+    BlackoutState,
+    blackout_key,
+    INSTRUMENT_CURRENCIES,
+    SUPPORTED_INSTRUMENTS,
+    BLACKOUT_WINDOW_MINUTES,
+    POLL_INTERVAL_SECONDS,
+    TTL_BLACKOUT,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_event(
+    event_time: datetime,
+    currency: str = "USD",
+    event_name: str = "Non-Farm Payrolls",
+    impact: str = "HIGH",
+) -> dict:
+    """Build a minimal event dict as returned by fetch_upcoming_high_impact_events."""
+    return {
+        "event_time": event_time,
+        "currency": currency,
+        "event_name": event_name,
+        "impact": impact,
+    }
+
+
+def _make_monitor(**kwargs) -> CalendarMonitor:
+    """Create a CalendarMonitor with default test params."""
+    defaults = dict(
+        db_host="localhost",
+        db_port=5432,
+        db_name="agentictrader",
+        db_user="agentictrader",
+        db_password="changeme",
+        redis_host="localhost",
+        redis_port=6379,
+    )
+    defaults.update(kwargs)
+    return CalendarMonitor(**defaults)
+
+
+# ===========================================================================
+# 1. blackout_key format
+# ===========================================================================
+
+def test_blackout_key_format():
+    """blackout_key('EURUSD') must return 'blackout:EURUSD'."""
+    assert blackout_key("EURUSD") == "blackout:EURUSD"
+
+
+# ===========================================================================
+# 2–6. Instrument → currency mapping
+# ===========================================================================
+
+def test_instrument_currency_mapping_eurusd():
+    """EURUSD maps to ['EUR', 'USD']."""
+    assert INSTRUMENT_CURRENCIES["EURUSD"] == ["EUR", "USD"]
+
+
+def test_instrument_currency_mapping_gbpusd():
+    """GBPUSD maps to ['GBP', 'USD']."""
+    assert INSTRUMENT_CURRENCIES["GBPUSD"] == ["GBP", "USD"]
+
+
+def test_instrument_currency_mapping_us500():
+    """US500 maps to ['USD']."""
+    assert INSTRUMENT_CURRENCIES["US500"] == ["USD"]
+
+
+def test_instrument_currency_mapping_xauusd():
+    """XAUUSD maps to ['XAU', 'USD']."""
+    assert INSTRUMENT_CURRENCIES["XAUUSD"] == ["XAU", "USD"]
+
+
+def test_instrument_currency_mapping_btcusd():
+    """BTCUSD maps to [] (no currency blackout)."""
+    assert INSTRUMENT_CURRENCIES["BTCUSD"] == []
+
+
+# ===========================================================================
+# 7. Blackout active when event within 15 min BEFORE (event in future)
+# ===========================================================================
+
+def test_blackout_active_when_event_within_15min_before():
+    """Event 10 min in the future → active=True."""
+    monitor = _make_monitor()
+    now = datetime(2026, 1, 15, 8, 30, 0, tzinfo=timezone.utc)
+    event_time = now + timedelta(minutes=10)
+    events = [_make_event(event_time, currency="USD")]
+
+    state = monitor.compute_blackout_state("EURUSD", events, now)
+
+    assert state.active is True
+
+
+# ===========================================================================
+# 8. Blackout active when event within 15 min AFTER (event in past)
+# ===========================================================================
+
+def test_blackout_active_when_event_within_15min_after():
+    """Event 10 min in the past → active=True."""
+    monitor = _make_monitor()
+    now = datetime(2026, 1, 15, 8, 30, 0, tzinfo=timezone.utc)
+    event_time = now - timedelta(minutes=10)
+    events = [_make_event(event_time, currency="USD")]
+
+    state = monitor.compute_blackout_state("EURUSD", events, now)
+
+    assert state.active is True
+
+
+# ===========================================================================
+# 9. Blackout inactive when event outside window
+# ===========================================================================
+
+def test_blackout_inactive_when_event_outside_window():
+    """Event 20 min away → active=False (outside ±15 min window)."""
+    monitor = _make_monitor()
+    now = datetime(2026, 1, 15, 8, 30, 0, tzinfo=timezone.utc)
+    event_time = now + timedelta(minutes=20)
+    events = [_make_event(event_time, currency="USD")]
+
+    state = monitor.compute_blackout_state("EURUSD", events, now)
+
+    assert state.active is False
+
+
+# ===========================================================================
+# 10. Blackout inactive when no HIGH impact events
+# ===========================================================================
+
+def test_blackout_inactive_when_no_high_impact_events():
+    """Empty events list → active=False."""
+    monitor = _make_monitor()
+    now = datetime(2026, 1, 15, 8, 30, 0, tzinfo=timezone.utc)
+
+    state = monitor.compute_blackout_state("EURUSD", [], now)
+
+    assert state.active is False
+
+
+# ===========================================================================
+# 11. Blackout only triggers for HIGH impact
+# ===========================================================================
+
+def test_blackout_only_triggers_for_high_impact():
+    """MEDIUM impact event within window → active=False (fetch_upcoming already filters HIGH).
+
+    compute_blackout_state receives only HIGH events from the DB query.
+    When events list is empty (no HIGH events), active must be False.
+    """
+    monitor = _make_monitor()
+    now = datetime(2026, 1, 15, 8, 30, 0, tzinfo=timezone.utc)
+
+    # Simulate: no HIGH events were returned (MEDIUM was filtered by DB query)
+    state = monitor.compute_blackout_state("EURUSD", [], now)
+
+    assert state.active is False
+
+
+# ===========================================================================
+# 12. minutes_remaining positive for upcoming event
+# ===========================================================================
+
+def test_minutes_remaining_positive_for_upcoming_event():
+    """Event 5 min in the future → minutes_remaining ≈ +5.0."""
+    monitor = _make_monitor()
+    now = datetime(2026, 1, 15, 8, 30, 0, tzinfo=timezone.utc)
+    event_time = now + timedelta(minutes=5)
+    events = [_make_event(event_time)]
+
+    state = monitor.compute_blackout_state("EURUSD", events, now)
+
+    assert abs(state.minutes_remaining - 5.0) < 0.01
+
+
+# ===========================================================================
+# 13. minutes_remaining negative for past event
+# ===========================================================================
+
+def test_minutes_remaining_negative_for_past_event():
+    """Event 5 min in the past → minutes_remaining ≈ -5.0."""
+    monitor = _make_monitor()
+    now = datetime(2026, 1, 15, 8, 30, 0, tzinfo=timezone.utc)
+    event_time = now - timedelta(minutes=5)
+    events = [_make_event(event_time)]
+
+    state = monitor.compute_blackout_state("EURUSD", events, now)
+
+    assert abs(state.minutes_remaining - (-5.0)) < 0.01
+
+
+# ===========================================================================
+# 14. check_blackout queries correct time window
+# ===========================================================================
+
+@pytest.mark.asyncio
+async def test_check_blackout_queries_correct_time_window():
+    """fetch_upcoming_high_impact_events must query DB with ±15 min window."""
+    monitor = _make_monitor()
+
+    mock_pool = MagicMock()
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(return_value=[])
+
+    async_ctx = AsyncMock()
+    async_ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+    async_ctx.__aexit__ = AsyncMock(return_value=None)
+    mock_pool.acquire = MagicMock(return_value=async_ctx)
+
+    monitor._pool = mock_pool
+
+    await monitor.fetch_upcoming_high_impact_events(["USD", "EUR"])
+
+    mock_conn.fetch.assert_called_once()
+    call_args = mock_conn.fetch.call_args
+    sql = call_args[0][0]
+
+    # SQL must reference the 15-minute window
+    assert "15 minutes" in sql.lower() or "15" in sql
+    assert "HIGH" in sql
+    assert "impact" in sql.lower()
+
+
+# ===========================================================================
+# 15. publish_blackout_state sets Redis key
+# ===========================================================================
+
+@pytest.mark.asyncio
+async def test_publish_blackout_state_sets_redis_key():
+    """publish_blackout_state must call redis.set with key 'blackout:EURUSD'."""
+    monitor = _make_monitor()
+    mock_redis = AsyncMock()
+    monitor._redis = mock_redis
+
+    state = BlackoutState(
+        instrument="EURUSD",
+        active=True,
+        event_name="Non-Farm Payrolls",
+        minutes_remaining=5.0,
+    )
+
+    await monitor.publish_blackout_state(state)
+
+    mock_redis.set.assert_called_once()
+    call_args = mock_redis.set.call_args
+    key = call_args[0][0]
+    assert key == "blackout:EURUSD"
+
+
+# ===========================================================================
+# 16. publish_blackout_state sets TTL=120
+# ===========================================================================
+
+@pytest.mark.asyncio
+async def test_publish_blackout_state_sets_ttl_120s():
+    """publish_blackout_state must set TTL=120 on the Redis key."""
+    monitor = _make_monitor()
+    mock_redis = AsyncMock()
+    monitor._redis = mock_redis
+
+    state = BlackoutState(
+        instrument="EURUSD",
+        active=True,
+        event_name="Non-Farm Payrolls",
+        minutes_remaining=5.0,
+    )
+
+    await monitor.publish_blackout_state(state)
+
+    call_kwargs = mock_redis.set.call_args[1]
+    assert call_kwargs.get("ex") == 120
+
+
+# ===========================================================================
+# 17. publish inactive blackout when no events
+# ===========================================================================
+
+@pytest.mark.asyncio
+async def test_publish_inactive_blackout_when_no_events():
+    """When no HIGH events, check_instrument publishes active=False for the instrument."""
+    monitor = _make_monitor()
+    mock_redis = AsyncMock()
+    monitor._redis = mock_redis
+
+    mock_pool = MagicMock()
+    mock_conn = AsyncMock()
+    mock_conn.fetch = AsyncMock(return_value=[])
+
+    async_ctx = AsyncMock()
+    async_ctx.__aenter__ = AsyncMock(return_value=mock_conn)
+    async_ctx.__aexit__ = AsyncMock(return_value=None)
+    mock_pool.acquire = MagicMock(return_value=async_ctx)
+    monitor._pool = mock_pool
+
+    now = datetime(2026, 1, 15, 8, 30, 0, tzinfo=timezone.utc)
+    state = await monitor.check_instrument("EURUSD", now)
+
+    assert state.active is False
+    mock_redis.set.assert_called_once()
+    key = mock_redis.set.call_args[0][0]
+    assert key == "blackout:EURUSD"
+    value = json.loads(mock_redis.set.call_args[0][1])
+    assert value["active"] is False
+
+
+# ===========================================================================
+# 18. run_once polls all instruments
+# ===========================================================================
+
+@pytest.mark.asyncio
+async def test_run_once_polls_all_instruments():
+    """run_once() must call check_instrument for every instrument in SUPPORTED_INSTRUMENTS."""
+    monitor = _make_monitor()
+
+    checked_instruments = []
+
+    async def fake_check_instrument(instrument, now):
+        checked_instruments.append(instrument)
+        return BlackoutState(
+            instrument=instrument,
+            active=False,
+            event_name="",
+            minutes_remaining=0.0,
+        )
+
+    monitor.check_instrument = fake_check_instrument
+
+    states = await monitor.run_once()
+
+    assert set(checked_instruments) == set(SUPPORTED_INSTRUMENTS)
+    assert len(states) == len(SUPPORTED_INSTRUMENTS)
+
+
+# ===========================================================================
+# 19. CalendarMonitor initialization
+# ===========================================================================
+
+def test_calendar_monitor_initialization():
+    """Constructor must store db/redis config as instance attributes."""
+    monitor = CalendarMonitor(
+        db_host="db.example.com",
+        db_port=5433,
+        db_name="mydb",
+        db_user="myuser",
+        db_password="secret",
+        redis_host="redis.example.com",
+        redis_port=6380,
+    )
+
+    assert monitor._db_host == "db.example.com"
+    assert monitor._db_port == 5433
+    assert monitor._db_name == "mydb"
+    assert monitor._db_user == "myuser"
+    assert monitor._db_password == "secret"
+    assert monitor._redis_host == "redis.example.com"
+    assert monitor._redis_port == 6380
+
+
+# ===========================================================================
+# 20. connect() creates asyncpg pool
+# ===========================================================================
+
+@pytest.mark.asyncio
+async def test_connect_creates_asyncpg_pool():
+    """connect() must call asyncpg.create_pool with the configured DB params."""
+    monitor = _make_monitor()
+
+    with patch(
+        "services.nlp.calendar_monitor.asyncpg.create_pool",
+        new_callable=AsyncMock,
+    ) as mock_create_pool, patch(
+        "services.nlp.calendar_monitor.aioredis.Redis",
+    ) as mock_redis_cls:
+        mock_pool = AsyncMock()
+        mock_create_pool.return_value = mock_pool
+        mock_redis_cls.return_value = AsyncMock()
+
+        await monitor.connect()
+
+        mock_create_pool.assert_called_once()
+        assert monitor._pool is mock_pool
+
+
+# ===========================================================================
+# 21. close() closes pool and redis
+# ===========================================================================
+
+@pytest.mark.asyncio
+async def test_close_closes_pool_and_redis():
+    """close() must call pool.close() and redis.aclose()."""
+    monitor = _make_monitor()
+
+    mock_pool = AsyncMock()
+    mock_redis = AsyncMock()
+    monitor._pool = mock_pool
+    monitor._redis = mock_redis
+
+    await monitor.close()
+
+    mock_pool.close.assert_called_once()
+    mock_redis.aclose.assert_called_once()
+
+
+# ===========================================================================
+# 22. Redis value contains event_name field
+# ===========================================================================
+
+@pytest.mark.asyncio
+async def test_blackout_event_name_in_redis_value():
+    """Redis value JSON must contain the event_name field."""
+    monitor = _make_monitor()
+    mock_redis = AsyncMock()
+    monitor._redis = mock_redis
+
+    state = BlackoutState(
+        instrument="GBPUSD",
+        active=True,
+        event_name="UK GDP",
+        minutes_remaining=3.5,
+    )
+
+    await monitor.publish_blackout_state(state)
+
+    call_args = mock_redis.set.call_args
+    value = json.loads(call_args[0][1])
+    assert value["event_name"] == "UK GDP"
+    assert value["active"] is True
+    assert abs(value["minutes_remaining"] - 3.5) < 0.01
+
+
+# ===========================================================================
+# 23. Multiple events — uses nearest event
+# ===========================================================================
+
+def test_multiple_events_uses_nearest_event():
+    """When 2 HIGH events are in window, use the one with smallest abs(minutes_remaining)."""
+    monitor = _make_monitor()
+    now = datetime(2026, 1, 15, 8, 30, 0, tzinfo=timezone.utc)
+
+    # Event 1: 12 min in future
+    event1 = _make_event(now + timedelta(minutes=12), event_name="NFP")
+    # Event 2: 3 min in future (nearer)
+    event2 = _make_event(now + timedelta(minutes=3), event_name="CPI")
+
+    state = monitor.compute_blackout_state("EURUSD", [event1, event2], now)
+
+    assert state.active is True
+    assert state.event_name == "CPI"
+    assert abs(state.minutes_remaining - 3.0) < 0.01

--- a/backend/tests/test_inference_service.py
+++ b/backend/tests/test_inference_service.py
@@ -1,0 +1,1319 @@
+﻿"""
+Integration tests for the ML Inference FastAPI service.
+
+Tests cover:
+- POST /predict endpoint: request/response schema, confidence thresholds, HTF projections
+- GET /health endpoint: liveness check
+- ModelRegistry: stub fallback when models not registered
+- InferenceEngine: feature extraction and prediction pipeline
+- CandleConsumer: Kafka message handling and rolling window
+- SetupPublisher: setups.detected message schema
+- Confidence threshold gating (< 0.65 discard, 0.65-0.74 log only, >= 0.75 publish)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+_WORKSPACE_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _WORKSPACE_ROOT not in sys.path:
+    sys.path.insert(0, _WORKSPACE_ROOT)
+
+from ml.inference.main import (
+    CandleConsumer,
+    InferenceEngine,
+    ModelRegistry,
+    OHLCVCandle,
+    PredictRequest,
+    SetupPublisher,
+    create_app,
+    CONFIDENCE_FLOOR,
+    CONFIDENCE_LOG_ONLY,
+    PATTERN_LABELS,
+    REGIME_CLASSES,
+    TOPIC_CANDLES,
+    TOPIC_SETUPS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_candles(n: int = 5, base_price: float = 1.1000) -> List[Dict[str, Any]]:
+    """Build a list of n synthetic OHLCV candle dicts."""
+    candles = []
+    price = base_price
+    for i in range(n):
+        open_ = price
+        close = price + 0.0010 * (1 if i % 2 == 0 else -1)
+        high = max(open_, close) + 0.0005
+        low = min(open_, close) - 0.0005
+        # Use minutes to avoid hour overflow for large n
+        hour = (i * 5) // 60
+        minute = (i * 5) % 60
+        candles.append({
+            "time": f"2024-01-01T{hour:02d}:{minute:02d}:00Z",
+            "open": round(open_, 5),
+            "high": round(high, 5),
+            "low": round(low, 5),
+            "close": round(close, 5),
+            "volume": 1000.0 + i * 100,
+        })
+        price = close
+    return candles
+
+
+def _make_ohlcv_models(n: int = 5) -> List[OHLCVCandle]:
+    """Build a list of n OHLCVCandle Pydantic models."""
+    raw = _make_candles(n)
+    return [OHLCVCandle(**c) for c in raw]
+
+
+@pytest.fixture
+def sample_candles() -> List[Dict[str, Any]]:
+    return _make_candles(10)
+
+
+@pytest.fixture
+def sample_ohlcv_models() -> List[OHLCVCandle]:
+    return _make_ohlcv_models(10)
+
+
+@pytest.fixture
+def stub_registry() -> ModelRegistry:
+    """ModelRegistry with all models set to None (stub mode)."""
+    with patch.object(ModelRegistry, "load", return_value=None):
+        registry = ModelRegistry(tracking_uri="http://localhost:5000")
+        registry._regime_model = None
+        registry._pattern_model = None
+        registry._confluence_model = None
+        registry._loaded = True
+    return registry
+
+
+@pytest.fixture
+def mock_regime_model():
+    """Mock sklearn-compatible regime classifier."""
+    model = Mock()
+    model.predict = Mock(return_value=np.array([0]))  # TRENDING_BULLISH
+    return model
+
+
+@pytest.fixture
+def mock_pattern_model():
+    """Mock sklearn-compatible multi-label pattern detector."""
+    model = Mock()
+    # predict_proba returns list of (n_samples, 2) arrays  one per label
+    model.predict_proba = Mock(
+        return_value=[
+            np.array([[0.3, 0.7]]),  # BOS_CONFIRMED active
+            np.array([[0.8, 0.2]]),  # CHOCH_DETECTED inactive
+            np.array([[0.4, 0.6]]),  # BEARISH_ARRAY_REJECTION active
+            np.array([[0.9, 0.1]]),  # BULLISH_ARRAY_BOUNCE inactive
+            np.array([[0.3, 0.7]]),  # FVG_PRESENT active
+            np.array([[0.8, 0.2]]),  # LIQUIDITY_SWEEP inactive
+            np.array([[0.9, 0.1]]),  # ORDER_BLOCK inactive
+            np.array([[0.8, 0.2]]),  # INDUCEMENT inactive
+        ]
+    )
+    return model
+
+
+@pytest.fixture
+def mock_confluence_model():
+    """Mock sklearn-compatible confluence scorer."""
+    model = Mock()
+    model.predict_proba = Mock(return_value=np.array([[0.15, 0.85]]))  # 0.85 confidence
+    return model
+
+
+@pytest.fixture
+def registry_with_mocks(mock_regime_model, mock_pattern_model, mock_confluence_model):
+    """ModelRegistry with mock models injected."""
+    with patch.object(ModelRegistry, "load", return_value=None):
+        registry = ModelRegistry(tracking_uri="http://localhost:5000")
+        registry._regime_model = mock_regime_model
+        registry._pattern_model = mock_pattern_model
+        registry._confluence_model = mock_confluence_model
+        registry._loaded = True
+    return registry
+
+
+@pytest.fixture
+def inference_engine(registry_with_mocks) -> InferenceEngine:
+    return InferenceEngine(registry_with_mocks)
+
+
+@pytest.fixture
+def test_client(stub_registry) -> TestClient:
+    """FastAPI TestClient with stub models (no Kafka)."""
+    with patch("ml.inference.main.ModelRegistry", return_value=stub_registry):
+        app = create_app(registry=stub_registry)
+    return TestClient(app)
+
+
+# ===========================================================================
+# 1. Constants and schema tests
+# ===========================================================================
+
+
+class TestConstants:
+    """Verify module-level constants match the spec."""
+
+    def test_confidence_floor_is_0_65(self):
+        """CONFIDENCE_FLOOR must be 0.65 (hard discard threshold)."""
+        assert CONFIDENCE_FLOOR == 0.65
+
+    def test_confidence_log_only_is_0_75(self):
+        """CONFIDENCE_LOG_ONLY must be 0.75 (publish threshold)."""
+        assert CONFIDENCE_LOG_ONLY == 0.75
+
+    def test_topic_candles_name(self):
+        """Kafka input topic must be market.candles."""
+        assert TOPIC_CANDLES == "market.candles"
+
+    def test_topic_setups_name(self):
+        """Kafka output topic must be setups.detected."""
+        assert TOPIC_SETUPS == "setups.detected"
+
+    def test_regime_classes_count(self):
+        """Five regime classes must be defined."""
+        assert len(REGIME_CLASSES) == 5
+
+    def test_regime_classes_values(self):
+        """All five regime class labels must be present."""
+        expected = {
+            "TRENDING_BULLISH",
+            "TRENDING_BEARISH",
+            "RANGING",
+            "BREAKOUT",
+            "NEWS_DRIVEN",
+        }
+        assert set(REGIME_CLASSES) == expected
+
+    def test_pattern_labels_count(self):
+        """Eight pattern labels must be defined."""
+        assert len(PATTERN_LABELS) == 8
+
+    def test_pattern_labels_values(self):
+        """All eight pattern labels must be present."""
+        expected = {
+            "BOS_CONFIRMED",
+            "CHOCH_DETECTED",
+            "BEARISH_ARRAY_REJECTION",
+            "BULLISH_ARRAY_BOUNCE",
+            "FVG_PRESENT",
+            "LIQUIDITY_SWEEP",
+            "ORDER_BLOCK",
+            "INDUCEMENT",
+        }
+        assert set(PATTERN_LABELS) == expected
+
+
+# ===========================================================================
+# 2. ModelRegistry tests
+# ===========================================================================
+
+
+class TestModelRegistry:
+    """Tests for ModelRegistry  model loading and stub fallback."""
+
+    def test_registry_instantiates(self):
+        """ModelRegistry can be instantiated with a tracking URI."""
+        with patch("mlflow.set_tracking_uri"):
+            registry = ModelRegistry(tracking_uri="http://localhost:5000")
+        assert registry is not None
+
+    def test_registry_not_loaded_before_load_called(self):
+        """loaded property is False before load() is called."""
+        with patch("mlflow.set_tracking_uri"):
+            registry = ModelRegistry(tracking_uri="http://localhost:5000")
+        assert registry.loaded is False
+
+    def test_registry_loaded_after_load_called(self, stub_registry):
+        """loaded property is True after load() completes."""
+        assert stub_registry.loaded is True
+
+    def test_stub_regime_returns_ranging(self, stub_registry):
+        """Stub regime model returns RANGING by default."""
+        X = np.zeros((1, 10))
+        result = stub_registry.predict_regime(X)
+        assert result == "RANGING"
+
+    def test_stub_patterns_returns_empty_list(self, stub_registry):
+        """Stub pattern model returns empty list by default."""
+        X = np.zeros((1, 10))
+        result = stub_registry.predict_patterns(X)
+        assert result == []
+
+    def test_stub_confidence_returns_zero(self, stub_registry):
+        """Stub confluence model returns 0.0 by default."""
+        X = np.zeros((1, 10))
+        result = stub_registry.predict_confidence(X)
+        assert result == 0.0
+
+    def test_regime_model_returns_class_label(self, registry_with_mocks):
+        """predict_regime returns a valid REGIME_CLASSES label."""
+        X = np.zeros((1, 10))
+        result = registry_with_mocks.predict_regime(X)
+        assert result in REGIME_CLASSES
+
+    def test_pattern_model_returns_list_of_labels(self, registry_with_mocks):
+        """predict_patterns returns a list of PATTERN_LABELS strings."""
+        X = np.zeros((1, 10))
+        result = registry_with_mocks.predict_patterns(X)
+        assert isinstance(result, list)
+        for label in result:
+            assert label in PATTERN_LABELS
+
+    def test_confidence_model_returns_float_in_range(self, registry_with_mocks):
+        """predict_confidence returns a float in [0.0, 1.0]."""
+        X = np.zeros((1, 10))
+        result = registry_with_mocks.predict_confidence(X)
+        assert isinstance(result, float)
+        assert 0.0 <= result <= 1.0
+
+    def test_load_falls_back_to_stub_when_mlflow_unavailable(self):
+        """load() installs stub predictors when MLflow registry is unreachable."""
+        with patch("mlflow.set_tracking_uri"), \
+             patch("mlflow.tracking.MlflowClient") as mock_client_cls:
+            mock_client = Mock()
+            mock_client.get_latest_versions.side_effect = Exception("Connection refused")
+            mock_client_cls.return_value = mock_client
+
+            registry = ModelRegistry(tracking_uri="http://localhost:5000")
+            registry.load()
+
+        assert registry.loaded is True
+        # All models should be None (stub mode)
+        assert registry._regime_model is None
+        assert registry._pattern_model is None
+        assert registry._confluence_model is None
+
+
+# ===========================================================================
+# 3. InferenceEngine tests
+# ===========================================================================
+
+
+class TestInferenceEngine:
+    """Tests for InferenceEngine  feature extraction and prediction."""
+
+    def test_engine_instantiates(self, stub_registry):
+        """InferenceEngine can be instantiated with a registry."""
+        engine = InferenceEngine(stub_registry)
+        assert engine is not None
+
+    def test_predict_returns_required_keys(self, inference_engine, sample_candles):
+        """predict() returns a dict with all required keys."""
+        result = inference_engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        required_keys = {
+            "time",
+            "regime",
+            "patterns",
+            "confidence_score",
+            "htf_projections",
+            "entry_price",
+            "sl_price",
+            "tp_price",
+        }
+        assert required_keys.issubset(set(result.keys()))
+
+    def test_predict_regime_is_valid_class(self, inference_engine, sample_candles):
+        """predict() returns a valid regime class label."""
+        result = inference_engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        assert result["regime"] in REGIME_CLASSES
+
+    def test_predict_patterns_is_list(self, inference_engine, sample_candles):
+        """predict() returns patterns as a list."""
+        result = inference_engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        assert isinstance(result["patterns"], list)
+
+    def test_predict_confidence_score_in_range(self, inference_engine, sample_candles):
+        """predict() returns confidence_score in [0.0, 1.0]."""
+        result = inference_engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        assert 0.0 <= result["confidence_score"] <= 1.0
+
+    def test_predict_htf_projections_has_required_fields(self, inference_engine, sample_candles):
+        """predict() returns htf_projections with all required fields."""
+        result = inference_engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        htf = result["htf_projections"]
+        required_htf_keys = {
+            "htf_timeframe",
+            "htf_open",
+            "htf_high",
+            "htf_low",
+            "open_bias",
+            "htf_high_proximity_pct",
+            "htf_low_proximity_pct",
+            "htf_body_pct",
+            "htf_upper_wick_pct",
+            "htf_lower_wick_pct",
+            "htf_close_position",
+        }
+        assert required_htf_keys.issubset(set(htf.keys()))
+
+    def test_predict_open_bias_is_valid_enum(self, inference_engine, sample_candles):
+        """predict() returns open_bias in {BULLISH, BEARISH, NEUTRAL}."""
+        result = inference_engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        assert result["htf_projections"]["open_bias"] in {"BULLISH", "BEARISH", "NEUTRAL"}
+
+    def test_predict_raises_on_single_candle(self, inference_engine):
+        """predict() raises ValueError when fewer than 2 candles provided."""
+        single_candle = _make_candles(1)
+        with pytest.raises(ValueError, match="At least 2 candles"):
+            inference_engine.predict(
+                instrument="EURUSD",
+                timeframe="M5",
+                candles=single_candle,
+            )
+
+    def test_predict_trade_levels_none_when_confidence_below_floor(self, stub_registry, sample_candles):
+        """entry/sl/tp are None when confidence < CONFIDENCE_FLOOR (stub returns 0.0)."""
+        engine = InferenceEngine(stub_registry)
+        result = engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        # Stub confidence is 0.0 < 0.65
+        assert result["entry_price"] is None
+        assert result["sl_price"] is None
+        assert result["tp_price"] is None
+
+    def test_predict_trade_levels_set_when_confidence_above_floor(
+        self, registry_with_mocks, sample_candles
+    ):
+        """entry/sl/tp are set when confidence >= CONFIDENCE_FLOOR and bias is not NEUTRAL."""
+        engine = InferenceEngine(registry_with_mocks)
+        result = engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        # Mock confidence is 0.85 >= 0.65
+        # Trade levels depend on open_bias  if NEUTRAL they remain None
+        confidence = result["confidence_score"]
+        assert confidence >= CONFIDENCE_FLOOR
+        # If bias is directional, levels should be set
+        if result["htf_projections"]["open_bias"] in ("BULLISH", "BEARISH"):
+            assert result["entry_price"] is not None
+            assert result["sl_price"] is not None
+            assert result["tp_price"] is not None
+
+    def test_predict_time_is_string(self, inference_engine, sample_candles):
+        """predict() returns time as a string."""
+        result = inference_engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        assert isinstance(result["time"], str)
+
+    def test_predict_htf_timeframe_is_higher_than_input(
+        self, inference_engine, sample_candles
+    ):
+        """HTF timeframe returned is always a higher timeframe than the input.
+
+        The engine uses INTRADAY_STANDARD style which maps all inputs to D1 bias.
+        The key invariant is that the returned htf_timeframe is a valid timeframe
+        string and is present in the htf_projections dict.
+        """
+        result = inference_engine.predict(
+            instrument="EURUSD",
+            timeframe="M5",
+            candles=sample_candles,
+        )
+        htf_tf = result["htf_projections"]["htf_timeframe"]
+        # Must be a non-empty string
+        assert isinstance(htf_tf, str)
+        assert len(htf_tf) > 0
+        # Must be a known timeframe
+        valid_timeframes = {"M1", "M3", "M5", "M15", "M30", "H1", "H4", "D1", "W1", "MN1"}
+        assert htf_tf in valid_timeframes, f"Unknown HTF timeframe: {htf_tf}"
+        # For M5 input with INTRADAY_STANDARD style, bias TF should be D1
+        assert htf_tf == "D1", f"Expected D1 for M5 INTRADAY_STANDARD, got {htf_tf}"
+
+
+# ===========================================================================
+# 4. POST /predict endpoint tests
+# ===========================================================================
+
+
+class TestPredictEndpoint:
+    """Integration tests for POST /predict."""
+
+    @pytest.fixture
+    def client(self, stub_registry) -> TestClient:
+        app = create_app(registry=stub_registry)
+        return TestClient(app)
+
+    def _predict_payload(self, n_candles: int = 5, instrument: str = "EURUSD", timeframe: str = "M5") -> Dict:
+        candles = [
+            {
+                "time": f"2024-01-01T{i:02d}:00:00Z",
+                "open": 1.1000 + i * 0.001,
+                "high": 1.1010 + i * 0.001,
+                "low": 1.0990 + i * 0.001,
+                "close": 1.1005 + i * 0.001,
+                "volume": 1000.0,
+            }
+            for i in range(n_candles)
+        ]
+        return {"instrument": instrument, "timeframe": timeframe, "candles": candles}
+
+    def test_predict_returns_200(self, client):
+        """POST /predict returns HTTP 200 for valid payload."""
+        response = client.post("/predict", json=self._predict_payload())
+        assert response.status_code == 200
+
+    def test_predict_response_has_instrument(self, client):
+        """POST /predict response includes instrument field."""
+        response = client.post("/predict", json=self._predict_payload(instrument="XAUUSD"))
+        assert response.status_code == 200
+        assert response.json()["instrument"] == "XAUUSD"
+
+    def test_predict_response_has_timeframe(self, client):
+        """POST /predict response includes timeframe field."""
+        response = client.post("/predict", json=self._predict_payload(timeframe="H1"))
+        assert response.status_code == 200
+        assert response.json()["timeframe"] == "H1"
+
+    def test_predict_response_has_regime(self, client):
+        """POST /predict response includes regime field."""
+        response = client.post("/predict", json=self._predict_payload())
+        assert response.status_code == 200
+        assert "regime" in response.json()
+        assert response.json()["regime"] in REGIME_CLASSES
+
+    def test_predict_response_has_patterns_list(self, client):
+        """POST /predict response includes patterns as a list."""
+        response = client.post("/predict", json=self._predict_payload())
+        assert response.status_code == 200
+        assert isinstance(response.json()["patterns"], list)
+
+    def test_predict_response_has_confidence_score(self, client):
+        """POST /predict response includes confidence_score in [0, 1]."""
+        response = client.post("/predict", json=self._predict_payload())
+        assert response.status_code == 200
+        score = response.json()["confidence_score"]
+        assert 0.0 <= score <= 1.0
+
+    def test_predict_response_has_htf_projections(self, client):
+        """POST /predict response includes htf_projections object."""
+        response = client.post("/predict", json=self._predict_payload())
+        assert response.status_code == 200
+        htf = response.json()["htf_projections"]
+        assert "htf_open" in htf
+        assert "htf_high" in htf
+        assert "htf_low" in htf
+        assert "open_bias" in htf
+
+    def test_predict_response_htf_open_bias_valid(self, client):
+        """POST /predict response open_bias is in valid enum set."""
+        response = client.post("/predict", json=self._predict_payload())
+        assert response.status_code == 200
+        bias = response.json()["htf_projections"]["open_bias"]
+        assert bias in {"BULLISH", "BEARISH", "NEUTRAL"}
+
+    def test_predict_response_has_time_field(self, client):
+        """POST /predict response includes time field."""
+        response = client.post("/predict", json=self._predict_payload())
+        assert response.status_code == 200
+        assert "time" in response.json()
+
+    def test_predict_rejects_single_candle(self, client):
+        """POST /predict returns 422 when only 1 candle provided."""
+        payload = self._predict_payload(n_candles=1)
+        response = client.post("/predict", json=payload)
+        assert response.status_code == 422
+
+    def test_predict_rejects_empty_candles(self, client):
+        """POST /predict returns 422 when candles list is empty."""
+        payload = {"instrument": "EURUSD", "timeframe": "M5", "candles": []}
+        response = client.post("/predict", json=payload)
+        assert response.status_code == 422
+
+    def test_predict_accepts_optional_reference_prices(self, client):
+        """POST /predict accepts optional daily_open, weekly_open, true_day_open."""
+        payload = self._predict_payload()
+        payload["daily_open"] = 1.1000
+        payload["weekly_open"] = 1.0950
+        payload["true_day_open"] = 1.1010
+        response = client.post("/predict", json=payload)
+        assert response.status_code == 200
+
+    def test_predict_all_supported_instruments(self, client):
+        """POST /predict works for all 12 supported instruments."""
+        instruments = [
+            "XAUUSD", "EURUSD", "GBPUSD", "EURAUD", "GBPAUD",
+            "USDJPY", "US100", "US30", "US500", "GER40", "BTCUSD", "ETHUSD",
+        ]
+        for instrument in instruments:
+            response = client.post("/predict", json=self._predict_payload(instrument=instrument))
+            assert response.status_code == 200, f"Failed for instrument {instrument}"
+
+    def test_predict_all_supported_timeframes(self, client):
+        """POST /predict works for all supported timeframes."""
+        timeframes = ["M1", "M5", "M15", "H1", "H4", "D1"]
+        for tf in timeframes:
+            response = client.post("/predict", json=self._predict_payload(timeframe=tf))
+            assert response.status_code == 200, f"Failed for timeframe {tf}"
+
+    def test_predict_stub_confidence_below_floor_no_trade_levels(self, client):
+        """Stub confidence (0.0) means entry/sl/tp are null in response."""
+        response = client.post("/predict", json=self._predict_payload())
+        assert response.status_code == 200
+        data = response.json()
+        # Stub returns 0.0 confidence < 0.65 floor
+        assert data["entry_price"] is None
+        assert data["sl_price"] is None
+        assert data["tp_price"] is None
+
+
+# ===========================================================================
+# 5. GET /health endpoint tests
+# ===========================================================================
+
+
+class TestHealthEndpoint:
+    """Tests for GET /health liveness check."""
+
+    @pytest.fixture
+    def client(self, stub_registry) -> TestClient:
+        app = create_app(registry=stub_registry)
+        return TestClient(app)
+
+    def test_health_returns_200(self, client):
+        """GET /health returns HTTP 200."""
+        response = client.get("/health")
+        assert response.status_code == 200
+
+    def test_health_response_has_status_ok(self, client):
+        """GET /health response has status='ok'."""
+        response = client.get("/health")
+        assert response.json()["status"] == "ok"
+
+    def test_health_response_has_models_loaded(self, client):
+        """GET /health response includes models_loaded boolean."""
+        response = client.get("/health")
+        assert "models_loaded" in response.json()
+        assert isinstance(response.json()["models_loaded"], bool)
+
+    def test_health_response_has_kafka_consumer_running(self, client):
+        """GET /health response includes kafka_consumer_running boolean."""
+        response = client.get("/health")
+        assert "kafka_consumer_running" in response.json()
+        assert isinstance(response.json()["kafka_consumer_running"], bool)
+
+    def test_health_models_loaded_true_when_registry_loaded(self, stub_registry):
+        """models_loaded is True when registry.loaded is True."""
+        app = create_app(registry=stub_registry)
+        client = TestClient(app)
+        response = client.get("/health")
+        assert response.json()["models_loaded"] is True
+
+    def test_health_kafka_consumer_false_without_kafka(self, stub_registry):
+        """kafka_consumer_running is False when no Kafka consumer is running."""
+        app = create_app(registry=stub_registry)
+        client = TestClient(app)
+        response = client.get("/health")
+        # No Kafka in test environment
+        assert response.json()["kafka_consumer_running"] is False
+
+
+# ===========================================================================
+# 6. Confidence threshold gating tests
+# ===========================================================================
+
+
+class TestConfidenceThresholds:
+    """Tests for confidence threshold gating in InferenceEngine._derive_trade_levels."""
+
+    def _make_htf_proj(self, open_bias: str = "BULLISH") -> Dict[str, Any]:
+        return {
+            "htf_timeframe": "H1",
+            "htf_open": 1.1000,
+            "htf_high": 1.1200,
+            "htf_low": 1.0800,
+            "open_bias": open_bias,
+            "htf_high_proximity_pct": 30.0,
+            "htf_low_proximity_pct": 70.0,
+            "htf_body_pct": 60.0,
+            "htf_upper_wick_pct": 20.0,
+            "htf_lower_wick_pct": 20.0,
+            "htf_close_position": 0.8,
+        }
+
+    def _make_candle(self, close: float = 1.1050) -> Dict[str, Any]:
+        return {"time": "2024-01-01T00:00:00Z", "open": 1.1000, "high": 1.1100, "low": 1.0950, "close": close, "volume": 1000}
+
+    def test_confidence_below_floor_returns_none_levels(self, stub_registry):
+        """confidence < 0.65 -> entry/sl/tp all None."""
+        engine = InferenceEngine(stub_registry)
+        entry, sl, tp = engine._derive_trade_levels(
+            current_candle=self._make_candle(),
+            htf_proj=self._make_htf_proj("BULLISH"),
+            confidence_score=0.60,
+        )
+        assert entry is None
+        assert sl is None
+        assert tp is None
+
+    def test_confidence_at_floor_minus_epsilon_returns_none(self, stub_registry):
+        """confidence = 0.6499 (just below floor) -> None levels."""
+        engine = InferenceEngine(stub_registry)
+        entry, sl, tp = engine._derive_trade_levels(
+            current_candle=self._make_candle(),
+            htf_proj=self._make_htf_proj("BULLISH"),
+            confidence_score=0.6499,
+        )
+        assert entry is None
+
+    def test_confidence_at_floor_returns_levels(self, stub_registry):
+        """confidence = 0.65 (at floor) -> trade levels set for directional bias."""
+        engine = InferenceEngine(stub_registry)
+        entry, sl, tp = engine._derive_trade_levels(
+            current_candle=self._make_candle(close=1.1050),
+            htf_proj=self._make_htf_proj("BULLISH"),
+            confidence_score=0.65,
+        )
+        assert entry is not None
+        assert sl is not None
+        assert tp is not None
+
+    def test_confidence_above_floor_returns_levels(self, stub_registry):
+        """confidence = 0.85 -> trade levels set."""
+        engine = InferenceEngine(stub_registry)
+        entry, sl, tp = engine._derive_trade_levels(
+            current_candle=self._make_candle(close=1.1050),
+            htf_proj=self._make_htf_proj("BULLISH"),
+            confidence_score=0.85,
+        )
+        assert entry is not None
+
+    def test_bullish_bias_entry_is_close_sl_is_htf_low(self, stub_registry):
+        """Bullish bias: entry=close, sl=htf_low, tp=htf_high."""
+        engine = InferenceEngine(stub_registry)
+        close = 1.1050
+        htf_proj = self._make_htf_proj("BULLISH")
+        entry, sl, tp = engine._derive_trade_levels(
+            current_candle=self._make_candle(close=close),
+            htf_proj=htf_proj,
+            confidence_score=0.80,
+        )
+        assert entry == pytest.approx(close)
+        assert sl == pytest.approx(htf_proj["htf_low"])
+        assert tp == pytest.approx(htf_proj["htf_high"])
+
+    def test_bearish_bias_entry_is_close_sl_is_htf_high(self, stub_registry):
+        """Bearish bias: entry=close, sl=htf_high, tp=htf_low."""
+        engine = InferenceEngine(stub_registry)
+        close = 1.1050
+        htf_proj = self._make_htf_proj("BEARISH")
+        entry, sl, tp = engine._derive_trade_levels(
+            current_candle=self._make_candle(close=close),
+            htf_proj=htf_proj,
+            confidence_score=0.80,
+        )
+        assert entry == pytest.approx(close)
+        assert sl == pytest.approx(htf_proj["htf_high"])
+        assert tp == pytest.approx(htf_proj["htf_low"])
+
+    def test_neutral_bias_returns_none_levels(self, stub_registry):
+        """NEUTRAL bias -> no trade levels regardless of confidence."""
+        engine = InferenceEngine(stub_registry)
+        entry, sl, tp = engine._derive_trade_levels(
+            current_candle=self._make_candle(),
+            htf_proj=self._make_htf_proj("NEUTRAL"),
+            confidence_score=0.90,
+        )
+        assert entry is None
+        assert sl is None
+        assert tp is None
+
+
+# ===========================================================================
+# 7. setups.detected message schema tests
+# ===========================================================================
+
+
+class TestSetupsDetectedSchema:
+    """Tests for the setups.detected Kafka message schema."""
+
+    REQUIRED_FIELDS = {
+        "instrument",
+        "timeframe",
+        "time",
+        "regime",
+        "patterns",
+        "confidence_score",
+        "htf_open",
+        "htf_high",
+        "htf_low",
+        "open_bias",
+        "entry_price",
+        "sl_price",
+        "tp_price",
+    }
+
+    def _build_setup_msg(self, **overrides) -> Dict[str, Any]:
+        base = {
+            "instrument": "EURUSD",
+            "timeframe": "M5",
+            "time": "2024-01-01T10:00:00Z",
+            "regime": "TRENDING_BULLISH",
+            "patterns": ["BOS_CONFIRMED", "FVG_PRESENT"],
+            "confidence_score": 0.82,
+            "htf_open": 1.1000,
+            "htf_high": 1.1200,
+            "htf_low": 1.0800,
+            "open_bias": "BULLISH",
+            "entry_price": 1.1050,
+            "sl_price": 1.0800,
+            "tp_price": 1.1200,
+        }
+        base.update(overrides)
+        return base
+
+    def test_setup_msg_has_all_required_fields(self):
+        """setups.detected message contains all 13 required fields."""
+        msg = self._build_setup_msg()
+        assert self.REQUIRED_FIELDS.issubset(set(msg.keys()))
+
+    def test_setup_msg_instrument_is_string(self):
+        """instrument field is a string."""
+        msg = self._build_setup_msg()
+        assert isinstance(msg["instrument"], str)
+
+    def test_setup_msg_timeframe_is_string(self):
+        """timeframe field is a string."""
+        msg = self._build_setup_msg()
+        assert isinstance(msg["timeframe"], str)
+
+    def test_setup_msg_regime_is_valid_class(self):
+        """regime field is a valid REGIME_CLASSES value."""
+        msg = self._build_setup_msg()
+        assert msg["regime"] in REGIME_CLASSES
+
+    def test_setup_msg_patterns_is_list(self):
+        """patterns field is a list."""
+        msg = self._build_setup_msg()
+        assert isinstance(msg["patterns"], list)
+
+    def test_setup_msg_confidence_score_in_range(self):
+        """confidence_score is in [0.0, 1.0]."""
+        msg = self._build_setup_msg()
+        assert 0.0 <= msg["confidence_score"] <= 1.0
+
+    def test_setup_msg_open_bias_valid(self):
+        """open_bias is in {BULLISH, BEARISH, NEUTRAL}."""
+        msg = self._build_setup_msg()
+        assert msg["open_bias"] in {"BULLISH", "BEARISH", "NEUTRAL"}
+
+    def test_setup_msg_is_json_serialisable(self):
+        """setups.detected message can be JSON-serialised."""
+        msg = self._build_setup_msg()
+        serialised = json.dumps(msg, default=str)
+        deserialised = json.loads(serialised)
+        assert deserialised["instrument"] == msg["instrument"]
+        assert deserialised["confidence_score"] == msg["confidence_score"]
+
+    def test_setup_msg_htf_levels_are_numeric(self):
+        """htf_open, htf_high, htf_low are numeric."""
+        msg = self._build_setup_msg()
+        assert isinstance(msg["htf_open"], (int, float))
+        assert isinstance(msg["htf_high"], (int, float))
+        assert isinstance(msg["htf_low"], (int, float))
+
+    def test_setup_msg_htf_high_gte_htf_low(self):
+        """htf_high >= htf_low (valid OHLC range)."""
+        msg = self._build_setup_msg()
+        assert msg["htf_high"] >= msg["htf_low"]
+
+
+# ===========================================================================
+# 8. CandleConsumer rolling window tests
+# ===========================================================================
+
+
+class TestCandleConsumer:
+    """Tests for CandleConsumer rolling window and message handling."""
+
+    def _make_consumer(self) -> CandleConsumer:
+        """Build a CandleConsumer with mock engine and publisher."""
+        mock_engine = Mock(spec=InferenceEngine)
+        mock_engine.predict = Mock(return_value={
+            "time": "2024-01-01T00:00:00Z",
+            "regime": "RANGING",
+            "patterns": [],
+            "confidence_score": 0.0,
+            "htf_projections": {
+                "htf_timeframe": "H1",
+                "htf_open": 1.1000,
+                "htf_high": 1.1200,
+                "htf_low": 1.0800,
+                "open_bias": "NEUTRAL",
+                "htf_high_proximity_pct": 50.0,
+                "htf_low_proximity_pct": 50.0,
+                "htf_body_pct": 60.0,
+                "htf_upper_wick_pct": 20.0,
+                "htf_lower_wick_pct": 20.0,
+                "htf_close_position": 0.5,
+            },
+            "entry_price": None,
+            "sl_price": None,
+            "tp_price": None,
+        })
+        mock_publisher = Mock(spec=SetupPublisher)
+        mock_publisher.publish = AsyncMock()
+        return CandleConsumer(
+            bootstrap_servers="localhost:9092",
+            engine=mock_engine,
+            publisher=mock_publisher,
+        )
+
+    def _make_candle_msg(
+        self,
+        instrument: str = "EURUSD",
+        timeframe: str = "M5",
+        complete: bool = True,
+        idx: int = 0,
+    ) -> Dict[str, Any]:
+        return {
+            "instrument": instrument,
+            "timeframe": timeframe,
+            "time": f"2024-01-01T{idx:02d}:00:00Z",
+            "open": 1.1000 + idx * 0.001,
+            "high": 1.1010 + idx * 0.001,
+            "low": 1.0990 + idx * 0.001,
+            "close": 1.1005 + idx * 0.001,
+            "volume": 1000.0,
+            "complete": complete,
+            "source": "oanda",
+        }
+
+    @pytest.mark.asyncio
+    async def test_incomplete_candle_not_processed(self):
+        """Incomplete candles (complete=False) are ignored."""
+        consumer = self._make_consumer()
+        msg = self._make_candle_msg(complete=False)
+        await consumer._handle_message(msg)
+        consumer.engine.predict.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_complete_candle_triggers_inference(self):
+        """Complete candles trigger inference after 2+ candles in window."""
+        consumer = self._make_consumer()
+        # Send 2 complete candles to build the window
+        for i in range(2):
+            await consumer._handle_message(self._make_candle_msg(complete=True, idx=i))
+        consumer.engine.predict.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_single_complete_candle_no_inference(self):
+        """Single complete candle does not trigger inference (need >= 2)."""
+        consumer = self._make_consumer()
+        await consumer._handle_message(self._make_candle_msg(complete=True, idx=0))
+        consumer.engine.predict.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rolling_window_capped_at_window_size(self):
+        """Rolling window is capped at WINDOW_SIZE (50) candles."""
+        consumer = self._make_consumer()
+        key = "EURUSD:M5"
+        # Send WINDOW_SIZE + 10 candles
+        for i in range(CandleConsumer.WINDOW_SIZE + 10):
+            await consumer._handle_message(self._make_candle_msg(complete=True, idx=i))
+        assert len(consumer._windows[key]) == CandleConsumer.WINDOW_SIZE
+
+    @pytest.mark.asyncio
+    async def test_separate_windows_per_instrument_timeframe(self):
+        """Separate rolling windows maintained per instrument:timeframe key."""
+        consumer = self._make_consumer()
+        for i in range(3):
+            await consumer._handle_message(
+                self._make_candle_msg(instrument="EURUSD", timeframe="M5", complete=True, idx=i)
+            )
+        for i in range(2):
+            await consumer._handle_message(
+                self._make_candle_msg(instrument="XAUUSD", timeframe="H1", complete=True, idx=i)
+            )
+        assert "EURUSD:M5" in consumer._windows
+        assert "XAUUSD:H1" in consumer._windows
+        assert len(consumer._windows["EURUSD:M5"]) == 3
+        assert len(consumer._windows["XAUUSD:H1"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_candle_missing_instrument_skipped(self):
+        """Candles without instrument field are skipped."""
+        consumer = self._make_consumer()
+        msg = self._make_candle_msg(complete=True)
+        del msg["instrument"]
+        await consumer._handle_message(msg)
+        consumer.engine.predict.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_candle_missing_timeframe_skipped(self):
+        """Candles without timeframe field are skipped."""
+        consumer = self._make_consumer()
+        msg = self._make_candle_msg(complete=True)
+        del msg["timeframe"]
+        await consumer._handle_message(msg)
+        consumer.engine.predict.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_low_confidence_setup_not_published(self):
+        """Setups with confidence < CONFIDENCE_FLOOR are not published."""
+        consumer = self._make_consumer()
+        # Engine returns 0.0 confidence (stub)
+        for i in range(3):
+            await consumer._handle_message(self._make_candle_msg(complete=True, idx=i))
+        consumer.publisher.publish.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_high_confidence_setup_published(self):
+        """Setups with confidence >= CONFIDENCE_LOG_ONLY (0.75) are published."""
+        consumer = self._make_consumer()
+        # Override engine to return high confidence
+        consumer.engine.predict = Mock(return_value={
+            "time": "2024-01-01T00:00:00Z",
+            "regime": "TRENDING_BULLISH",
+            "patterns": ["BOS_CONFIRMED"],
+            "confidence_score": 0.82,
+            "htf_projections": {
+                "htf_timeframe": "H1",
+                "htf_open": 1.1000,
+                "htf_high": 1.1200,
+                "htf_low": 1.0800,
+                "open_bias": "BULLISH",
+                "htf_high_proximity_pct": 30.0,
+                "htf_low_proximity_pct": 70.0,
+                "htf_body_pct": 60.0,
+                "htf_upper_wick_pct": 20.0,
+                "htf_lower_wick_pct": 20.0,
+                "htf_close_position": 0.8,
+            },
+            "entry_price": 1.1050,
+            "sl_price": 1.0800,
+            "tp_price": 1.1200,
+        })
+        for i in range(3):
+            await consumer._handle_message(self._make_candle_msg(complete=True, idx=i))
+        consumer.publisher.publish.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_log_only_confidence_not_published(self):
+        """Setups with 0.65 <= confidence < 0.75 are logged but not published."""
+        consumer = self._make_consumer()
+        consumer.engine.predict = Mock(return_value={
+            "time": "2024-01-01T00:00:00Z",
+            "regime": "RANGING",
+            "patterns": [],
+            "confidence_score": 0.70,  # log-only range
+            "htf_projections": {
+                "htf_timeframe": "H1",
+                "htf_open": 1.1000,
+                "htf_high": 1.1200,
+                "htf_low": 1.0800,
+                "open_bias": "NEUTRAL",
+                "htf_high_proximity_pct": 50.0,
+                "htf_low_proximity_pct": 50.0,
+                "htf_body_pct": 60.0,
+                "htf_upper_wick_pct": 20.0,
+                "htf_lower_wick_pct": 20.0,
+                "htf_close_position": 0.5,
+            },
+            "entry_price": None,
+            "sl_price": None,
+            "tp_price": None,
+        })
+        for i in range(3):
+            await consumer._handle_message(self._make_candle_msg(complete=True, idx=i))
+        consumer.publisher.publish.assert_not_called()
+
+
+# ===========================================================================
+# 9. SetupPublisher tests
+# ===========================================================================
+
+
+class TestSetupPublisher:
+    """Tests for SetupPublisher Kafka producer."""
+
+    @pytest.mark.asyncio
+    async def test_publisher_instantiates(self):
+        """SetupPublisher can be instantiated with bootstrap_servers."""
+        publisher = SetupPublisher(bootstrap_servers="localhost:9092")
+        assert publisher is not None
+
+    @pytest.mark.asyncio
+    async def test_publisher_start_creates_producer(self):
+        """start() creates an AIOKafkaProducer instance."""
+        with patch("ml.inference.main.AIOKafkaProducer") as mock_producer_cls:
+            mock_producer = AsyncMock()
+            mock_producer_cls.return_value = mock_producer
+            publisher = SetupPublisher(bootstrap_servers="localhost:9092")
+            await publisher.start()
+            mock_producer.start.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_publisher_stop_flushes_and_stops(self):
+        """stop() flushes pending messages and stops the producer."""
+        with patch("ml.inference.main.AIOKafkaProducer") as mock_producer_cls:
+            mock_producer = AsyncMock()
+            mock_producer_cls.return_value = mock_producer
+            publisher = SetupPublisher(bootstrap_servers="localhost:9092")
+            await publisher.start()
+            await publisher.stop()
+            mock_producer.flush.assert_called_once()
+            mock_producer.stop.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_publisher_publish_sends_to_setups_topic(self):
+        """publish() sends message to setups.detected topic."""
+        with patch("ml.inference.main.AIOKafkaProducer") as mock_producer_cls:
+            mock_producer = AsyncMock()
+            mock_producer_cls.return_value = mock_producer
+            publisher = SetupPublisher(bootstrap_servers="localhost:9092")
+            await publisher.start()
+
+            setup = {
+                "instrument": "EURUSD",
+                "timeframe": "M5",
+                "time": "2024-01-01T10:00:00Z",
+                "regime": "TRENDING_BULLISH",
+                "patterns": ["BOS_CONFIRMED"],
+                "confidence_score": 0.82,
+                "htf_open": 1.1000,
+                "htf_high": 1.1200,
+                "htf_low": 1.0800,
+                "open_bias": "BULLISH",
+                "entry_price": 1.1050,
+                "sl_price": 1.0800,
+                "tp_price": 1.1200,
+            }
+            await publisher.publish(setup)
+
+            mock_producer.send.assert_called_once()
+            call_args = mock_producer.send.call_args
+            assert call_args[0][0] == TOPIC_SETUPS
+            assert call_args[1]["key"] == b"EURUSD:M5"
+
+    @pytest.mark.asyncio
+    async def test_publisher_publish_json_encodes_message(self):
+        """publish() JSON-encodes the setup message."""
+        with patch("ml.inference.main.AIOKafkaProducer") as mock_producer_cls:
+            mock_producer = AsyncMock()
+            mock_producer_cls.return_value = mock_producer
+            publisher = SetupPublisher(bootstrap_servers="localhost:9092")
+            await publisher.start()
+
+            setup = {
+                "instrument": "XAUUSD",
+                "timeframe": "H1",
+                "time": "2024-01-01T10:00:00Z",
+                "regime": "BREAKOUT",
+                "patterns": [],
+                "confidence_score": 0.78,
+                "htf_open": 2380.0,
+                "htf_high": 2400.0,
+                "htf_low": 2360.0,
+                "open_bias": "BULLISH",
+                "entry_price": 2385.0,
+                "sl_price": 2360.0,
+                "tp_price": 2400.0,
+            }
+            await publisher.publish(setup)
+
+            call_args = mock_producer.send.call_args
+            value_bytes = call_args[1]["value"]
+            decoded = json.loads(value_bytes.decode())
+            assert decoded["instrument"] == "XAUUSD"
+            assert decoded["confidence_score"] == 0.78
+
+
+# ===========================================================================
+# 10. Integration test: full app lifecycle
+# ===========================================================================
+
+
+class TestAppLifecycle:
+    """Integration tests for the full FastAPI app lifecycle."""
+
+    def test_app_starts_and_stops_cleanly(self, stub_registry):
+        """App lifespan starts and stops without errors."""
+        app = create_app(registry=stub_registry)
+        # Simulate lifespan startup and shutdown
+        with TestClient(app) as client:
+            response = client.get("/health")
+            assert response.status_code == 200
+
+    def test_app_loads_models_on_startup(self, stub_registry):
+        """App calls registry.load() during startup."""
+        with patch.object(ModelRegistry, "load") as mock_load:
+            app = create_app(registry=stub_registry)
+            with TestClient(app):
+                pass
+            # load() should have been called during lifespan startup
+            # (already called in fixture, so we just verify registry is loaded)
+            assert stub_registry.loaded is True
+
+    def test_app_exposes_predict_endpoint(self, test_client):
+        """App exposes POST /predict endpoint."""
+        response = test_client.post(
+            "/predict",
+            json={
+                "instrument": "EURUSD",
+                "timeframe": "M5",
+                "candles": _make_candles(5),
+            },
+        )
+        assert response.status_code == 200
+
+    def test_app_exposes_health_endpoint(self, test_client):
+        """App exposes GET /health endpoint."""
+        response = test_client.get("/health")
+        assert response.status_code == 200
+
+    def test_app_title_and_version(self, stub_registry):
+        """App has correct title and version."""
+        app = create_app(registry=stub_registry)
+        assert "AgentICTrader" in app.title
+        assert app.version == "1.0.0"
+
+
+# ===========================================================================
+# 11. Error handling tests
+# ===========================================================================
+
+
+class TestErrorHandling:
+    """Tests for error handling in the inference service."""
+
+    @pytest.fixture
+    def client(self, stub_registry) -> TestClient:
+        app = create_app(registry=stub_registry)
+        return TestClient(app)
+
+    def test_predict_invalid_json_returns_422(self, client):
+        """POST /predict with invalid JSON returns 422."""
+        response = client.post("/predict", data="not json")
+        assert response.status_code == 422
+
+    def test_predict_missing_required_field_returns_422(self, client):
+        """POST /predict missing required field returns 422."""
+        response = client.post(
+            "/predict",
+            json={"instrument": "EURUSD"},  # missing timeframe and candles
+        )
+        assert response.status_code == 422
+
+    def test_predict_invalid_candle_schema_returns_422(self, client):
+        """POST /predict with invalid candle schema returns 422."""
+        response = client.post(
+            "/predict",
+            json={
+                "instrument": "EURUSD",
+                "timeframe": "M5",
+                "candles": [{"invalid": "schema"}],
+            },
+        )
+        assert response.status_code == 422
+
+    def test_predict_engine_exception_returns_500(self, stub_registry):
+        """POST /predict returns 500 when InferenceEngine raises exception."""
+        with patch.object(InferenceEngine, "predict", side_effect=RuntimeError("Test error")):
+            app = create_app(registry=stub_registry)
+            client = TestClient(app)
+            response = client.post(
+                "/predict",
+                json={
+                    "instrument": "EURUSD",
+                    "timeframe": "M5",
+                    "candles": _make_candles(5),
+                },
+            )
+            assert response.status_code == 500
+            assert "Inference failed" in response.json()["detail"]
+
+
+# ===========================================================================
+# 12. Performance and latency tests
+# ===========================================================================
+
+
+class TestPerformance:
+    """Performance and latency tests for the inference service."""
+
+    @pytest.mark.slow
+    def test_predict_latency_under_500ms(self, test_client):
+        """POST /predict completes in < 500ms (NFR-1 requirement)."""
+        import time
+
+        payload = {
+            "instrument": "EURUSD",
+            "timeframe": "M5",
+            "candles": _make_candles(50),
+        }
+        start = time.time()
+        response = test_client.post("/predict", json=payload)
+        elapsed = time.time() - start
+
+        assert response.status_code == 200
+        assert elapsed < 0.5, f"Predict took {elapsed:.3f}s (> 500ms)"
+
+    @pytest.mark.slow
+    def test_health_latency_under_100ms(self, test_client):
+        """GET /health completes in < 100ms."""
+        import time
+
+        start = time.time()
+        response = test_client.get("/health")
+        elapsed = time.time() - start
+
+        assert response.status_code == 200
+        assert elapsed < 0.1, f"Health check took {elapsed:.3f}s (> 100ms)"
+
+
+
+

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -1,0 +1,746 @@
+"""
+Unit tests for services/nlp/llm_service.py
+
+TDD: RED → GREEN → REFACTOR
+Run: pytest backend/tests/test_llm_service.py -v
+
+All external dependencies (Anthropic Claude API) are mocked.
+Tests do NOT require network access or a valid API key.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.nlp.llm_service import (
+    LLMService,
+    CLAUDE_MODEL,
+    _PHASE_DESCRIPTIONS,
+    _WINDOW_LABELS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_service(api_key: str = "test-key") -> LLMService:
+    """Return an LLMService with a mocked Anthropic client."""
+    with patch("services.nlp.llm_service.anthropic") as mock_anthropic:
+        mock_client = MagicMock()
+        mock_anthropic.Anthropic.return_value = mock_client
+        service = LLMService(anthropic_api_key=api_key)
+        service._client = mock_client
+    return service
+
+
+def _make_service_no_key() -> LLMService:
+    """Return an LLMService with no API key (template-only mode)."""
+    return LLMService(anthropic_api_key="")
+
+
+def _mock_claude_response(text: str) -> MagicMock:
+    """Build a mock Anthropic messages.create() response."""
+    mock_content = MagicMock()
+    mock_content.text = text
+    mock_response = MagicMock()
+    mock_response.content = [mock_content]
+    return mock_response
+
+
+def _sample_event(**overrides) -> dict:
+    """Return a sample macro event dict."""
+    base = {
+        "event_name": "Non-Farm Payrolls",
+        "currency": "USD",
+        "impact": "HIGH",
+        "actual": "256K",
+        "forecast": "200K",
+        "previous": "212K",
+        "event_time": "2026-05-14T12:30:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+def _sample_setup(**overrides) -> dict:
+    """Return a sample trade setup dict."""
+    base = {
+        "instrument": "EURUSD",
+        "direction": "BULLISH",
+        "htf_open_bias": "BULLISH",
+        "htf_open": 1.08500,
+        "htf_high": 1.09200,
+        "htf_low": 1.07800,
+        "time_window": "LONDON_KILLZONE",
+        "narrative_phase": "MANIPULATION",
+        "price_vs_daily_open": "BELOW",
+        "price_vs_weekly_open": "BELOW",
+        "price_vs_true_day_open": "BELOW",
+        "patterns": ["LIQUIDITY_SWEEP", "FVG_PRESENT"],
+        "confidence_score": 0.82,
+        "entry_price": 1.08650,
+        "sl_price": 1.08400,
+        "tp_price": 1.09150,
+        "swing_high": 1.09100,
+        "swing_low": 1.07900,
+        "fvg_present": True,
+        "session_sweep_time": "03:15 NY",
+        "session_sweep_level": "Asian range low",
+    }
+    base.update(overrides)
+    return base
+
+
+# ===========================================================================
+# 1. LLMService initialisation
+# ===========================================================================
+
+class TestLLMServiceInit:
+    def test_init_with_api_key_creates_client(self):
+        """LLMService with a valid API key should create an Anthropic client."""
+        mock_anthropic = MagicMock()
+        mock_client = MagicMock()
+        mock_anthropic.Anthropic.return_value = mock_client
+        with patch("services.nlp.llm_service._ANTHROPIC_AVAILABLE", True), \
+             patch("services.nlp.llm_service.anthropic", mock_anthropic):
+            service = LLMService(anthropic_api_key="sk-test-key")
+            assert service._client is not None
+            mock_anthropic.Anthropic.assert_called_once_with(api_key="sk-test-key")
+
+    def test_init_without_api_key_no_client(self):
+        """LLMService with empty API key should have _client=None."""
+        service = LLMService(anthropic_api_key="")
+        assert service._client is None
+
+    def test_init_stores_model_name(self):
+        """LLMService should store the claude_model parameter."""
+        service = LLMService(anthropic_api_key="", claude_model="claude-3-opus-20240229")
+        assert service._claude_model == "claude-3-opus-20240229"
+
+    def test_init_default_model_is_claude_model_constant(self):
+        """Default model should match the CLAUDE_MODEL constant."""
+        service = LLMService(anthropic_api_key="")
+        assert service._claude_model == CLAUDE_MODEL
+
+    def test_init_stores_max_tokens(self):
+        """LLMService should store the max_tokens parameter."""
+        service = LLMService(anthropic_api_key="", max_tokens=256)
+        assert service._max_tokens == 256
+
+
+# ===========================================================================
+# 2. summarise_macro_event — Claude path
+# ===========================================================================
+
+class TestSummariseMacroEventClaude:
+    @pytest.mark.asyncio
+    async def test_summarise_calls_claude_messages_create(self):
+        """summarise_macro_event should call client.messages.create when client is set."""
+        service = _make_service()
+        expected_text = "NFP beat expectations — bullish USD bias."
+        service._client.messages.create.return_value = _mock_claude_response(expected_text)
+
+        result = await service.summarise_macro_event(_sample_event())
+
+        service._client.messages.create.assert_called_once()
+        assert result == expected_text
+
+    @pytest.mark.asyncio
+    async def test_summarise_passes_correct_model(self):
+        """summarise_macro_event should pass the configured model to Claude."""
+        service = _make_service()
+        service._client.messages.create.return_value = _mock_claude_response("summary")
+
+        await service.summarise_macro_event(_sample_event())
+
+        call_kwargs = service._client.messages.create.call_args[1]
+        assert call_kwargs["model"] == CLAUDE_MODEL
+
+    @pytest.mark.asyncio
+    async def test_summarise_passes_event_name_in_prompt(self):
+        """The event_name should appear in the prompt sent to Claude."""
+        service = _make_service()
+        service._client.messages.create.return_value = _mock_claude_response("summary")
+
+        await service.summarise_macro_event(_sample_event(event_name="FOMC Rate Decision"))
+
+        call_kwargs = service._client.messages.create.call_args[1]
+        messages = call_kwargs["messages"]
+        prompt_text = messages[0]["content"]
+        assert "FOMC Rate Decision" in prompt_text
+
+    @pytest.mark.asyncio
+    async def test_summarise_returns_stripped_string(self):
+        """summarise_macro_event should strip leading/trailing whitespace from Claude response."""
+        service = _make_service()
+        service._client.messages.create.return_value = _mock_claude_response(
+            "  NFP beat expectations.  "
+        )
+
+        result = await service.summarise_macro_event(_sample_event())
+
+        assert result == "NFP beat expectations."
+
+    @pytest.mark.asyncio
+    async def test_summarise_returns_non_empty_string(self):
+        """summarise_macro_event should always return a non-empty string."""
+        service = _make_service()
+        service._client.messages.create.return_value = _mock_claude_response("Some summary.")
+
+        result = await service.summarise_macro_event(_sample_event())
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.asyncio
+    async def test_summarise_passes_currency_in_prompt(self):
+        """The currency should appear in the prompt sent to Claude."""
+        service = _make_service()
+        service._client.messages.create.return_value = _mock_claude_response("summary")
+
+        await service.summarise_macro_event(_sample_event(currency="EUR"))
+
+        call_kwargs = service._client.messages.create.call_args[1]
+        messages = call_kwargs["messages"]
+        prompt_text = messages[0]["content"]
+        assert "EUR" in prompt_text
+
+
+# ===========================================================================
+# 3. summarise_macro_event — fallback path
+# ===========================================================================
+
+class TestSummariseMacroEventFallback:
+    @pytest.mark.asyncio
+    async def test_summarise_falls_back_when_no_client(self):
+        """summarise_macro_event should use template fallback when _client is None."""
+        service = _make_service_no_key()
+
+        result = await service.summarise_macro_event(_sample_event())
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.asyncio
+    async def test_summarise_falls_back_on_claude_exception(self):
+        """summarise_macro_event should fall back to template when Claude raises."""
+        service = _make_service()
+        service._client.messages.create.side_effect = Exception("API error")
+
+        result = await service.summarise_macro_event(_sample_event())
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.asyncio
+    async def test_summarise_template_includes_event_name(self):
+        """Template fallback should include the event_name in the output."""
+        service = _make_service_no_key()
+
+        result = await service.summarise_macro_event(
+            _sample_event(event_name="UK CPI")
+        )
+
+        assert "UK CPI" in result
+
+    @pytest.mark.asyncio
+    async def test_summarise_template_includes_currency(self):
+        """Template fallback should include the currency in the output."""
+        service = _make_service_no_key()
+
+        result = await service.summarise_macro_event(
+            _sample_event(currency="GBP")
+        )
+
+        assert "GBP" in result
+
+    @pytest.mark.asyncio
+    async def test_summarise_template_beat_expectations(self):
+        """Template fallback should note 'beat expectations' when actual > forecast."""
+        service = _make_service_no_key()
+
+        result = await service.summarise_macro_event(
+            _sample_event(actual="300", forecast="200")
+        )
+
+        assert "beat" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_summarise_template_missed_expectations(self):
+        """Template fallback should note 'missed expectations' when actual < forecast."""
+        service = _make_service_no_key()
+
+        result = await service.summarise_macro_event(
+            _sample_event(actual="150", forecast="200")
+        )
+
+        assert "missed" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_summarise_template_met_expectations(self):
+        """Template fallback should note 'met expectations' when actual == forecast."""
+        service = _make_service_no_key()
+
+        result = await service.summarise_macro_event(
+            _sample_event(actual="200", forecast="200")
+        )
+
+        assert "met" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_summarise_template_handles_missing_actual(self):
+        """Template fallback should not crash when actual/forecast are absent."""
+        service = _make_service_no_key()
+
+        result = await service.summarise_macro_event(
+            {"event_name": "FOMC Minutes", "currency": "USD", "impact": "HIGH"}
+        )
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.asyncio
+    async def test_summarise_template_includes_impact(self):
+        """Template fallback should include the impact level."""
+        service = _make_service_no_key()
+
+        result = await service.summarise_macro_event(
+            _sample_event(impact="HIGH")
+        )
+
+        assert "HIGH" in result or "high" in result.lower()
+
+
+# ===========================================================================
+# 4. generate_trade_reasoning — Claude path
+# ===========================================================================
+
+class TestGenerateTradeReasoningClaude:
+    @pytest.mark.asyncio
+    async def test_reasoning_calls_claude_messages_create(self):
+        """generate_trade_reasoning should call client.messages.create when client is set."""
+        service = _make_service()
+        expected_text = (
+            "Price swept the Asian range low at 03:15 NY (London Killzone — manipulation phase). "
+            "HTF open bias is bullish. Price is below the True Day Open with a bullish FVG at discount. "
+            "Expecting expansion higher into the NY Killzone (07:00–10:00 NY) toward HTF high at 1.09200."
+        )
+        service._client.messages.create.return_value = _mock_claude_response(expected_text)
+
+        result = await service.generate_trade_reasoning(_sample_setup())
+
+        service._client.messages.create.assert_called_once()
+        assert result == expected_text
+
+    @pytest.mark.asyncio
+    async def test_reasoning_passes_correct_model(self):
+        """generate_trade_reasoning should pass the configured model to Claude."""
+        service = _make_service()
+        service._client.messages.create.return_value = _mock_claude_response("reasoning")
+
+        await service.generate_trade_reasoning(_sample_setup())
+
+        call_kwargs = service._client.messages.create.call_args[1]
+        assert call_kwargs["model"] == CLAUDE_MODEL
+
+    @pytest.mark.asyncio
+    async def test_reasoning_passes_instrument_in_prompt(self):
+        """The instrument should appear in the prompt sent to Claude."""
+        service = _make_service()
+        service._client.messages.create.return_value = _mock_claude_response("reasoning")
+
+        await service.generate_trade_reasoning(_sample_setup(instrument="XAUUSD"))
+
+        call_kwargs = service._client.messages.create.call_args[1]
+        messages = call_kwargs["messages"]
+        prompt_text = messages[0]["content"]
+        assert "XAUUSD" in prompt_text
+
+    @pytest.mark.asyncio
+    async def test_reasoning_passes_direction_in_prompt(self):
+        """The direction should appear in the prompt sent to Claude."""
+        service = _make_service()
+        service._client.messages.create.return_value = _mock_claude_response("reasoning")
+
+        await service.generate_trade_reasoning(_sample_setup(direction="BEARISH"))
+
+        call_kwargs = service._client.messages.create.call_args[1]
+        messages = call_kwargs["messages"]
+        prompt_text = messages[0]["content"]
+        assert "BEARISH" in prompt_text
+
+    @pytest.mark.asyncio
+    async def test_reasoning_passes_htf_bias_in_prompt(self):
+        """The HTF open bias should appear in the prompt sent to Claude."""
+        service = _make_service()
+        service._client.messages.create.return_value = _mock_claude_response("reasoning")
+
+        await service.generate_trade_reasoning(_sample_setup(htf_open_bias="BULLISH"))
+
+        call_kwargs = service._client.messages.create.call_args[1]
+        messages = call_kwargs["messages"]
+        prompt_text = messages[0]["content"]
+        assert "BULLISH" in prompt_text
+
+    @pytest.mark.asyncio
+    async def test_reasoning_passes_time_window_in_prompt(self):
+        """The time window label should appear in the prompt sent to Claude."""
+        service = _make_service()
+        service._client.messages.create.return_value = _mock_claude_response("reasoning")
+
+        await service.generate_trade_reasoning(
+            _sample_setup(time_window="LONDON_KILLZONE")
+        )
+
+        call_kwargs = service._client.messages.create.call_args[1]
+        messages = call_kwargs["messages"]
+        prompt_text = messages[0]["content"]
+        assert "London Killzone" in prompt_text
+
+    @pytest.mark.asyncio
+    async def test_reasoning_prompt_includes_3_question_framework(self):
+        """The prompt should reference all 3 narrative questions."""
+        service = _make_service()
+        service._client.messages.create.return_value = _mock_claude_response("reasoning")
+
+        await service.generate_trade_reasoning(_sample_setup())
+
+        call_kwargs = service._client.messages.create.call_args[1]
+        messages = call_kwargs["messages"]
+        prompt_text = messages[0]["content"]
+        assert "Where has price come from" in prompt_text
+        assert "Where is it now" in prompt_text
+        assert "Where is it likely to go" in prompt_text
+
+    @pytest.mark.asyncio
+    async def test_reasoning_bullish_prompt_includes_manipulation_wick_note(self):
+        """Bullish setup prompt should mention manipulation wick down before expansion up."""
+        service = _make_service()
+        service._client.messages.create.return_value = _mock_claude_response("reasoning")
+
+        await service.generate_trade_reasoning(_sample_setup(direction="BULLISH"))
+
+        call_kwargs = service._client.messages.create.call_args[1]
+        messages = call_kwargs["messages"]
+        prompt_text = messages[0]["content"]
+        assert "manipulation wick down" in prompt_text.lower() or "below session open" in prompt_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_reasoning_bearish_prompt_includes_manipulation_wick_note(self):
+        """Bearish setup prompt should mention manipulation wick up before expansion down."""
+        service = _make_service()
+        service._client.messages.create.return_value = _mock_claude_response("reasoning")
+
+        await service.generate_trade_reasoning(_sample_setup(direction="BEARISH"))
+
+        call_kwargs = service._client.messages.create.call_args[1]
+        messages = call_kwargs["messages"]
+        prompt_text = messages[0]["content"]
+        assert "manipulation wick up" in prompt_text.lower() or "above session open" in prompt_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_reasoning_returns_stripped_string(self):
+        """generate_trade_reasoning should strip whitespace from Claude response."""
+        service = _make_service()
+        service._client.messages.create.return_value = _mock_claude_response(
+            "  Price swept the Asian range low.  "
+        )
+
+        result = await service.generate_trade_reasoning(_sample_setup())
+
+        assert result == "Price swept the Asian range low."
+
+    @pytest.mark.asyncio
+    async def test_reasoning_returns_non_empty_string(self):
+        """generate_trade_reasoning should always return a non-empty string."""
+        service = _make_service()
+        service._client.messages.create.return_value = _mock_claude_response("Some reasoning.")
+
+        result = await service.generate_trade_reasoning(_sample_setup())
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+
+# ===========================================================================
+# 5. generate_trade_reasoning — fallback path
+# ===========================================================================
+
+class TestGenerateTradeReasoningFallback:
+    @pytest.mark.asyncio
+    async def test_reasoning_falls_back_when_no_client(self):
+        """generate_trade_reasoning should use template fallback when _client is None."""
+        service = _make_service_no_key()
+
+        result = await service.generate_trade_reasoning(_sample_setup())
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.asyncio
+    async def test_reasoning_falls_back_on_claude_exception(self):
+        """generate_trade_reasoning should fall back to template when Claude raises."""
+        service = _make_service()
+        service._client.messages.create.side_effect = Exception("API error")
+
+        result = await service.generate_trade_reasoning(_sample_setup())
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.asyncio
+    async def test_reasoning_template_includes_htf_bias(self):
+        """Template fallback should include the HTF open bias."""
+        service = _make_service_no_key()
+
+        result = await service.generate_trade_reasoning(
+            _sample_setup(htf_open_bias="BULLISH")
+        )
+
+        assert "BULLISH" in result
+
+    @pytest.mark.asyncio
+    async def test_reasoning_template_includes_time_window(self):
+        """Template fallback should include the time window."""
+        service = _make_service_no_key()
+
+        result = await service.generate_trade_reasoning(
+            _sample_setup(time_window="LONDON_KILLZONE")
+        )
+
+        assert "London Killzone" in result or "LONDON_KILLZONE" in result
+
+    @pytest.mark.asyncio
+    async def test_reasoning_template_includes_narrative_phase(self):
+        """Template fallback should include the narrative phase."""
+        service = _make_service_no_key()
+
+        result = await service.generate_trade_reasoning(
+            _sample_setup(narrative_phase="MANIPULATION")
+        )
+
+        assert "manipulation" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_reasoning_template_bullish_mentions_expansion_up(self):
+        """Template fallback for bullish setup should mention expansion higher."""
+        service = _make_service_no_key()
+
+        result = await service.generate_trade_reasoning(
+            _sample_setup(direction="BULLISH", htf_open_bias="BULLISH")
+        )
+
+        assert "expansion" in result.lower() or "higher" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_reasoning_template_bearish_mentions_expansion_down(self):
+        """Template fallback for bearish setup should mention expansion lower."""
+        service = _make_service_no_key()
+
+        result = await service.generate_trade_reasoning(
+            _sample_setup(direction="BEARISH", htf_open_bias="BEARISH")
+        )
+
+        assert "expansion" in result.lower() or "lower" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_reasoning_template_includes_session_sweep(self):
+        """Template fallback should include session sweep context when provided."""
+        service = _make_service_no_key()
+
+        result = await service.generate_trade_reasoning(
+            _sample_setup(
+                session_sweep_time="03:15 NY",
+                session_sweep_level="Asian range low",
+            )
+        )
+
+        assert "03:15 NY" in result or "Asian range low" in result
+
+    @pytest.mark.asyncio
+    async def test_reasoning_template_includes_fvg_when_present(self):
+        """Template fallback should mention FVG when fvg_present=True."""
+        service = _make_service_no_key()
+
+        result = await service.generate_trade_reasoning(
+            _sample_setup(fvg_present=True, htf_open_bias="BULLISH")
+        )
+
+        assert "fvg" in result.lower() or "imbalance" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_reasoning_template_includes_htf_high_for_bullish(self):
+        """Template fallback for bullish setup should reference HTF high as target."""
+        service = _make_service_no_key()
+
+        result = await service.generate_trade_reasoning(
+            _sample_setup(
+                direction="BULLISH",
+                htf_open_bias="BULLISH",
+                htf_high=1.09200,
+                swing_high=None,
+            )
+        )
+
+        assert "1.09200" in result or "htf high" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_reasoning_template_includes_htf_low_for_bearish(self):
+        """Template fallback for bearish setup should reference HTF low as target."""
+        service = _make_service_no_key()
+
+        result = await service.generate_trade_reasoning(
+            _sample_setup(
+                direction="BEARISH",
+                htf_open_bias="BEARISH",
+                htf_low=1.07800,
+                swing_low=None,
+            )
+        )
+
+        assert "1.07800" in result or "htf low" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_reasoning_template_includes_confidence_score(self):
+        """Template fallback should include the confidence score."""
+        service = _make_service_no_key()
+
+        result = await service.generate_trade_reasoning(
+            _sample_setup(confidence_score=0.82)
+        )
+
+        assert "82%" in result or "0.82" in result
+
+    @pytest.mark.asyncio
+    async def test_reasoning_template_includes_entry_sl_tp(self):
+        """Template fallback should include entry, SL, and TP prices."""
+        service = _make_service_no_key()
+
+        result = await service.generate_trade_reasoning(
+            _sample_setup(
+                entry_price=1.08650,
+                sl_price=1.08400,
+                tp_price=1.09150,
+            )
+        )
+
+        assert "1.0865" in result or "Entry" in result
+
+    @pytest.mark.asyncio
+    async def test_reasoning_template_handles_minimal_setup(self):
+        """Template fallback should not crash with a minimal setup dict."""
+        service = _make_service_no_key()
+
+        result = await service.generate_trade_reasoning({})
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.asyncio
+    async def test_reasoning_template_bullish_below_session_open_note(self):
+        """Template fallback for bullish setup should note price below session open."""
+        service = _make_service_no_key()
+
+        result = await service.generate_trade_reasoning(
+            _sample_setup(direction="BULLISH")
+        )
+
+        assert "below session open" in result.lower() or "manipulation wick down" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_reasoning_template_bearish_above_session_open_note(self):
+        """Template fallback for bearish setup should note price above session open."""
+        service = _make_service_no_key()
+
+        result = await service.generate_trade_reasoning(
+            _sample_setup(direction="BEARISH", htf_open_bias="BEARISH")
+        )
+
+        assert "above session open" in result.lower() or "manipulation wick up" in result.lower()
+
+
+# ===========================================================================
+# 6. Example output matches spec
+# ===========================================================================
+
+class TestExampleOutput:
+    @pytest.mark.asyncio
+    async def test_example_output_structure_matches_spec(self):
+        """
+        The spec example output is:
+        "Price swept the Asian range low at 03:15 NY (London Killzone — manipulation phase).
+         HTF open bias is bullish. Price is below the True Day Open with a bullish FVG at discount.
+         Expecting expansion higher into the NY Killzone (07:00–10:00 NY) toward HTF high at {price}."
+
+        The template fallback should produce output with the same structural elements.
+        """
+        service = _make_service_no_key()
+
+        result = await service.generate_trade_reasoning(
+            _sample_setup(
+                direction="BULLISH",
+                htf_open_bias="BULLISH",
+                htf_high=1.09200,
+                time_window="LONDON_KILLZONE",
+                narrative_phase="MANIPULATION",
+                price_vs_true_day_open="BELOW",
+                fvg_present=True,
+                session_sweep_time="03:15 NY",
+                session_sweep_level="Asian range low",
+                swing_high=None,
+            )
+        )
+
+        # Must contain all 4 structural elements from the spec example
+        assert "03:15 NY" in result or "Asian range low" in result  # Q1: where from
+        assert "bullish" in result.lower()                           # HTF bias
+        assert "below" in result.lower()                             # Q2: where now
+        assert "expansion" in result.lower() or "higher" in result.lower()  # Q3: where going
+
+    @pytest.mark.asyncio
+    async def test_claude_response_matches_spec_example(self):
+        """When Claude returns the spec example output, it should be returned verbatim."""
+        service = _make_service()
+        spec_example = (
+            "Price swept the Asian range low at 03:15 NY (London Killzone — manipulation phase). "
+            "HTF open bias is bullish. Price is below the True Day Open with a bullish FVG at discount. "
+            "Expecting expansion higher into the NY Killzone (07:00–10:00 NY) toward HTF high at 1.09200."
+        )
+        service._client.messages.create.return_value = _mock_claude_response(spec_example)
+
+        result = await service.generate_trade_reasoning(_sample_setup())
+
+        assert result == spec_example
+
+
+# ===========================================================================
+# 7. Constants
+# ===========================================================================
+
+class TestConstants:
+    def test_claude_model_constant_is_string(self):
+        assert isinstance(CLAUDE_MODEL, str)
+        assert len(CLAUDE_MODEL) > 0
+
+    def test_phase_descriptions_covers_all_phases(self):
+        expected_phases = {
+            "ACCUMULATION", "MANIPULATION", "EXPANSION",
+            "DISTRIBUTION", "TRANSITION", "OFF",
+        }
+        assert expected_phases.issubset(set(_PHASE_DESCRIPTIONS.keys()))
+
+    def test_window_labels_covers_all_windows(self):
+        expected_windows = {
+            "ASIAN_RANGE", "TRUE_DAY_OPEN", "LONDON_KILLZONE",
+            "LONDON_SILVER_BULLET", "NY_AM_KILLZONE", "NY_AM_SILVER_BULLET",
+            "LONDON_CLOSE", "NY_PM_KILLZONE", "NY_PM_SILVER_BULLET",
+            "NEWS_WINDOW", "DAILY_CLOSE", "OFF_HOURS",
+        }
+        assert expected_windows.issubset(set(_WINDOW_LABELS.keys()))
+
+    def test_window_labels_are_non_empty_strings(self):
+        for key, label in _WINDOW_LABELS.items():
+            assert isinstance(label, str), f"Label for {key} is not a string"
+            assert len(label) > 0, f"Label for {key} is empty"

--- a/backend/tests/test_sentiment_pipeline.py
+++ b/backend/tests/test_sentiment_pipeline.py
@@ -1,0 +1,748 @@
+"""
+Unit tests for services/nlp/sentiment_pipeline.py
+
+TDD: RED → GREEN → REFACTOR
+Run: pytest backend/tests/test_sentiment_pipeline.py -v
+
+All external dependencies (FinBERT model, HTTP calls, Kafka, Redis) are mocked.
+Tests do NOT require network access or GPU.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import fakeredis.aioredis as fakeredis
+
+from services.nlp.sentiment_pipeline import (
+    SentimentPipeline,
+    SentimentSignal,
+    NewsArticle,
+    SUPPORTED_INSTRUMENTS,
+    TOPIC_SENTIMENT,
+    TTL_SENTIMENT,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_finbert_positive():
+    """Mock FinBERT pipeline returning a positive label."""
+    with patch("services.nlp.sentiment_pipeline.pipeline") as mock_pipeline_fn:
+        mock_clf = MagicMock()
+        mock_clf.return_value = [{"label": "positive", "score": 0.9}]
+        mock_pipeline_fn.return_value = mock_clf
+        yield mock_clf
+
+
+@pytest.fixture
+def mock_finbert_negative():
+    """Mock FinBERT pipeline returning a negative label."""
+    with patch("services.nlp.sentiment_pipeline.pipeline") as mock_pipeline_fn:
+        mock_clf = MagicMock()
+        mock_clf.return_value = [{"label": "negative", "score": 0.8}]
+        mock_pipeline_fn.return_value = mock_clf
+        yield mock_clf
+
+
+@pytest.fixture
+def mock_finbert_neutral():
+    """Mock FinBERT pipeline returning a neutral label."""
+    with patch("services.nlp.sentiment_pipeline.pipeline") as mock_pipeline_fn:
+        mock_clf = MagicMock()
+        mock_clf.return_value = [{"label": "neutral", "score": 0.95}]
+        mock_pipeline_fn.return_value = mock_clf
+        yield mock_clf
+
+
+@pytest.fixture
+def mock_kafka():
+    """Mock AIOKafkaProducer."""
+    with patch("services.nlp.sentiment_pipeline.AIOKafkaProducer") as mock_cls:
+        mock_producer = AsyncMock()
+        mock_producer.start = AsyncMock()
+        mock_producer.stop = AsyncMock()
+        mock_producer.flush = AsyncMock()
+        mock_producer.send = AsyncMock()
+        mock_cls.return_value = mock_producer
+        yield mock_producer
+
+
+@pytest.fixture
+def fake_redis():
+    """In-process fakeredis instance (no real Redis required)."""
+    return fakeredis.FakeRedis(decode_responses=True)
+
+
+@pytest.fixture
+def mock_alpha_vantage_response():
+    """Mock aiohttp response for Alpha Vantage with one recent article."""
+    mock_resp = AsyncMock()
+    mock_resp.status = 200
+    mock_resp.json = AsyncMock(
+        return_value={
+            "feed": [
+                {
+                    "title": "Fed raises rates",
+                    "summary": "Federal Reserve raises interest rates by 25bps",
+                    "time_published": "20260514T103000",
+                    "source": "Reuters",
+                    "url": "https://reuters.com/article/1",
+                }
+            ]
+        }
+    )
+    return mock_resp
+
+
+@pytest.fixture
+def sample_articles():
+    """A list of two recent NewsArticle objects."""
+    now = datetime.now(tz=timezone.utc)
+    return [
+        NewsArticle(
+            title="EUR rises on ECB decision",
+            summary="The euro gained against the dollar after ECB raised rates.",
+            published_at=now - timedelta(hours=1),
+            source="alpha_vantage",
+            url="https://example.com/1",
+        ),
+        NewsArticle(
+            title="Eurozone inflation data",
+            summary="Eurozone CPI came in above expectations.",
+            published_at=now - timedelta(hours=2),
+            source="alpha_vantage",
+            url="https://example.com/2",
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a connected pipeline with mocked Kafka + Redis
+# ---------------------------------------------------------------------------
+
+def _make_pipeline(fake_redis_instance=None, api_key="test_key") -> SentimentPipeline:
+    """Return a SentimentPipeline with mocked internals (no real connections)."""
+    sp = SentimentPipeline(
+        kafka_bootstrap_servers="localhost:9092",
+        redis_host="localhost",
+        redis_port=6379,
+        alpha_vantage_api_key=api_key,
+    )
+    return sp
+
+
+# ===========================================================================
+# 1. SentimentSignal dataclass
+# ===========================================================================
+
+class TestSentimentSignalDataclass:
+    def test_sentiment_signal_has_required_fields(self):
+        signal = SentimentSignal(
+            instrument="EURUSD",
+            score=0.75,
+            direction="BULLISH",
+            freshness_seconds=120,
+            source="alpha_vantage",
+        )
+        assert signal.instrument == "EURUSD"
+        assert signal.score == 0.75
+        assert signal.direction == "BULLISH"
+        assert signal.freshness_seconds == 120
+        assert signal.source == "alpha_vantage"
+
+    def test_sentiment_signal_score_range(self):
+        signal = SentimentSignal(
+            instrument="XAUUSD",
+            score=-0.5,
+            direction="BEARISH",
+            freshness_seconds=60,
+            source="reuters_rss",
+        )
+        assert isinstance(signal.score, float)
+        assert signal.direction in ("BULLISH", "BEARISH", "NEUTRAL")
+
+
+# ===========================================================================
+# 2. NewsArticle dataclass
+# ===========================================================================
+
+class TestNewsArticleDataclass:
+    def test_news_article_has_required_fields(self):
+        now = datetime.now(tz=timezone.utc)
+        article = NewsArticle(
+            title="Gold hits record high",
+            summary="Gold prices surged to an all-time high amid safe-haven demand.",
+            published_at=now,
+            source="reuters",
+            url="https://reuters.com/gold",
+        )
+        assert article.title == "Gold hits record high"
+        assert "Gold prices" in article.summary
+        assert article.published_at == now
+        assert article.source == "reuters"
+        assert article.url == "https://reuters.com/gold"
+
+    def test_news_article_url_defaults_to_empty_string(self):
+        now = datetime.now(tz=timezone.utc)
+        article = NewsArticle(
+            title="Test",
+            summary="Summary",
+            published_at=now,
+            source="test",
+        )
+        assert article.url == ""
+
+
+# ===========================================================================
+# 3. score_to_direction
+# ===========================================================================
+
+class TestScoreToDirection:
+    def test_score_to_direction_bullish(self):
+        assert SentimentPipeline.score_to_direction(0.5) == "BULLISH"
+
+    def test_score_to_direction_bearish(self):
+        assert SentimentPipeline.score_to_direction(-0.5) == "BEARISH"
+
+    def test_score_to_direction_neutral_positive_boundary(self):
+        assert SentimentPipeline.score_to_direction(0.05) == "NEUTRAL"
+
+    def test_score_to_direction_neutral_negative_boundary(self):
+        assert SentimentPipeline.score_to_direction(-0.05) == "NEUTRAL"
+
+    def test_score_to_direction_exact_boundary_positive(self):
+        # score == 0.1 is NOT > 0.1, so it should be NEUTRAL
+        assert SentimentPipeline.score_to_direction(0.1) == "NEUTRAL"
+
+    def test_score_to_direction_exact_boundary_negative(self):
+        # score == -0.1 is NOT < -0.1, so it should be NEUTRAL
+        assert SentimentPipeline.score_to_direction(-0.1) == "NEUTRAL"
+
+    def test_score_to_direction_just_above_bullish_threshold(self):
+        assert SentimentPipeline.score_to_direction(0.101) == "BULLISH"
+
+    def test_score_to_direction_just_below_bearish_threshold(self):
+        assert SentimentPipeline.score_to_direction(-0.101) == "BEARISH"
+
+    def test_score_to_direction_zero(self):
+        assert SentimentPipeline.score_to_direction(0.0) == "NEUTRAL"
+
+
+# ===========================================================================
+# 4. classify_sentiment (mock FinBERT)
+# ===========================================================================
+
+class TestClassifySentiment:
+    def test_classify_sentiment_empty_articles_returns_zero(self):
+        sp = _make_pipeline()
+        result = sp.classify_sentiment([])
+        assert result == 0.0
+
+    def test_classify_sentiment_positive_articles(self, mock_finbert_positive, sample_articles):
+        sp = _make_pipeline()
+        result = sp.classify_sentiment(sample_articles)
+        assert result > 0
+
+    def test_classify_sentiment_negative_articles(self, mock_finbert_negative, sample_articles):
+        sp = _make_pipeline()
+        result = sp.classify_sentiment(sample_articles)
+        assert result < 0
+
+    def test_classify_sentiment_neutral_articles(self, mock_finbert_neutral, sample_articles):
+        sp = _make_pipeline()
+        result = sp.classify_sentiment(sample_articles)
+        assert result == 0.0
+
+    def test_classify_sentiment_mixed_articles(self, sample_articles):
+        """Mix of positive and negative → mean score."""
+        with patch("services.nlp.sentiment_pipeline.pipeline") as mock_pipeline_fn:
+            mock_clf = MagicMock()
+            # First call positive (0.8), second call negative (0.6) → mean = (0.8 - 0.6) / 2 = 0.1
+            mock_clf.side_effect = [
+                [{"label": "positive", "score": 0.8}],
+                [{"label": "negative", "score": 0.6}],
+            ]
+            mock_pipeline_fn.return_value = mock_clf
+
+            sp = _make_pipeline()
+            result = sp.classify_sentiment(sample_articles)
+            # mean of [+0.8, -0.6] = 0.1
+            assert abs(result - 0.1) < 1e-9
+
+    def test_classify_sentiment_score_clamped_to_minus_one_plus_one(self):
+        """Extreme confidence scores should be clamped to [-1.0, +1.0]."""
+        with patch("services.nlp.sentiment_pipeline.pipeline") as mock_pipeline_fn:
+            mock_clf = MagicMock()
+            # Return a score > 1.0 to test clamping (shouldn't happen in practice but be safe)
+            mock_clf.return_value = [{"label": "positive", "score": 1.5}]
+            mock_pipeline_fn.return_value = mock_clf
+
+            now = datetime.now(tz=timezone.utc)
+            articles = [
+                NewsArticle("title", "summary", now, "test"),
+            ]
+            sp = _make_pipeline()
+            result = sp.classify_sentiment(articles)
+            assert result <= 1.0
+
+    def test_classify_sentiment_single_article(self, mock_finbert_positive):
+        now = datetime.now(tz=timezone.utc)
+        articles = [NewsArticle("title", "summary", now, "test")]
+        sp = _make_pipeline()
+        result = sp.classify_sentiment(articles)
+        assert result == pytest.approx(0.9)
+
+    def test_classify_sentiment_loads_model_lazily(self):
+        """FinBERT should not be loaded at __init__ time."""
+        with patch("services.nlp.sentiment_pipeline.pipeline") as mock_pipeline_fn:
+            sp = _make_pipeline()
+            # Model should NOT have been loaded yet
+            mock_pipeline_fn.assert_not_called()
+            assert sp._classifier is None
+
+
+# ===========================================================================
+# 5. fetch_news (mock aiohttp)
+# ===========================================================================
+
+class TestFetchNews:
+    async def test_fetch_news_alpha_vantage_returns_articles(
+        self, mock_alpha_vantage_response
+    ):
+        sp = _make_pipeline(api_key="test_key")
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.get = MagicMock(return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=mock_alpha_vantage_response),
+            __aexit__=AsyncMock(return_value=False),
+        ))
+
+        with patch("services.nlp.sentiment_pipeline.aiohttp.ClientSession") as mock_cs:
+            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            articles = await sp.fetch_news("EURUSD")
+
+        assert len(articles) == 1
+        assert articles[0].title == "Fed raises rates"
+        assert articles[0].source == "Reuters"
+
+    async def test_fetch_news_filters_old_articles(self):
+        """Articles older than 24 hours should be excluded."""
+        old_time = datetime.now(tz=timezone.utc) - timedelta(hours=25)
+        old_time_str = old_time.strftime("%Y%m%dT%H%M%S")
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(
+            return_value={
+                "feed": [
+                    {
+                        "title": "Old news",
+                        "summary": "This is old",
+                        "time_published": old_time_str,
+                        "source": "Reuters",
+                        "url": "",
+                    }
+                ]
+            }
+        )
+
+        sp = _make_pipeline(api_key="test_key")
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=mock_resp),
+            __aexit__=AsyncMock(return_value=False),
+        ))
+
+        with patch("services.nlp.sentiment_pipeline.aiohttp.ClientSession") as mock_cs:
+            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            articles = await sp.fetch_news("EURUSD")
+
+        assert articles == []
+
+    async def test_fetch_news_http_error_returns_empty_list(self):
+        """aiohttp raising an exception should return an empty list, not raise."""
+        sp = _make_pipeline(api_key="test_key")
+
+        with patch("services.nlp.sentiment_pipeline.aiohttp.ClientSession") as mock_cs:
+            mock_cs.return_value.__aenter__ = AsyncMock(
+                side_effect=Exception("Connection refused")
+            )
+            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            articles = await sp.fetch_news("EURUSD")
+
+        assert articles == []
+
+    async def test_fetch_news_empty_feed_returns_empty_list(self):
+        """An empty feed array should return an empty list."""
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value={"feed": []})
+
+        sp = _make_pipeline(api_key="test_key")
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=mock_resp),
+            __aexit__=AsyncMock(return_value=False),
+        ))
+
+        with patch("services.nlp.sentiment_pipeline.aiohttp.ClientSession") as mock_cs:
+            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            articles = await sp.fetch_news("EURUSD")
+
+        assert articles == []
+
+    async def test_fetch_news_rss_fallback_when_no_api_key(self):
+        """When api_key is empty, the Reuters RSS URL should be used."""
+        rss_xml = """<?xml version="1.0"?>
+        <rss version="2.0">
+          <channel>
+            <item>
+              <title>Gold surges on safe haven demand</title>
+              <description>Gold prices rose sharply amid geopolitical tensions.</description>
+              <pubDate>Thu, 14 May 2026 10:30:00 +0000</pubDate>
+              <link>https://reuters.com/gold</link>
+            </item>
+          </channel>
+        </rss>"""
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.text = AsyncMock(return_value=rss_xml)
+
+        sp = _make_pipeline(api_key="")  # no API key → RSS fallback
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=mock_resp),
+            __aexit__=AsyncMock(return_value=False),
+        ))
+
+        with patch("services.nlp.sentiment_pipeline.aiohttp.ClientSession") as mock_cs:
+            mock_cs.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_cs.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            articles = await sp.fetch_news("XAUUSD")
+
+        # Should have fetched from RSS (gold keyword matches XAUUSD)
+        assert len(articles) >= 1
+        assert articles[0].source == "reuters_rss"
+
+
+# ===========================================================================
+# 6. compute_signal
+# ===========================================================================
+
+class TestComputeSignal:
+    async def test_compute_signal_returns_sentiment_signal(
+        self, mock_finbert_positive
+    ):
+        sp = _make_pipeline()
+        sp.fetch_news = AsyncMock(return_value=[])
+        signal = await sp.compute_signal("EURUSD")
+        assert isinstance(signal, SentimentSignal)
+        assert signal.instrument == "EURUSD"
+
+    async def test_compute_signal_score_in_valid_range(self, mock_finbert_positive, sample_articles):
+        sp = _make_pipeline()
+        sp.fetch_news = AsyncMock(return_value=sample_articles)
+        signal = await sp.compute_signal("EURUSD")
+        assert -1.0 <= signal.score <= 1.0
+
+    async def test_compute_signal_direction_matches_score(self, mock_finbert_positive, sample_articles):
+        sp = _make_pipeline()
+        sp.fetch_news = AsyncMock(return_value=sample_articles)
+        signal = await sp.compute_signal("EURUSD")
+        expected_direction = SentimentPipeline.score_to_direction(signal.score)
+        assert signal.direction == expected_direction
+
+    async def test_compute_signal_freshness_seconds_is_non_negative(
+        self, mock_finbert_positive, sample_articles
+    ):
+        sp = _make_pipeline()
+        sp.fetch_news = AsyncMock(return_value=sample_articles)
+        signal = await sp.compute_signal("EURUSD")
+        assert signal.freshness_seconds >= 0
+
+    async def test_compute_signal_no_articles_freshness_is_zero(self):
+        sp = _make_pipeline()
+        sp.fetch_news = AsyncMock(return_value=[])
+        signal = await sp.compute_signal("EURUSD")
+        assert signal.freshness_seconds == 0
+        assert signal.score == 0.0
+
+
+# ===========================================================================
+# 7. publish_signal (mock Kafka)
+# ===========================================================================
+
+class TestPublishSignal:
+    async def test_publish_signal_sends_to_correct_topic(self, mock_kafka):
+        sp = _make_pipeline()
+        sp._producer = mock_kafka
+
+        signal = SentimentSignal(
+            instrument="EURUSD",
+            score=0.5,
+            direction="BULLISH",
+            freshness_seconds=60,
+            source="alpha_vantage",
+        )
+        await sp.publish_signal(signal)
+
+        mock_kafka.send.assert_called_once()
+        call_args = mock_kafka.send.call_args
+        assert call_args[0][0] == TOPIC_SENTIMENT
+
+    async def test_publish_signal_key_is_instrument_bytes(self, mock_kafka):
+        sp = _make_pipeline()
+        sp._producer = mock_kafka
+
+        signal = SentimentSignal(
+            instrument="XAUUSD",
+            score=-0.3,
+            direction="BEARISH",
+            freshness_seconds=300,
+            source="reuters_rss",
+        )
+        await sp.publish_signal(signal)
+
+        call_kwargs = mock_kafka.send.call_args[1]
+        assert call_kwargs["key"] == b"XAUUSD"
+
+    async def test_publish_signal_value_contains_required_fields(self, mock_kafka):
+        sp = _make_pipeline()
+        sp._producer = mock_kafka
+
+        signal = SentimentSignal(
+            instrument="BTCUSD",
+            score=0.2,
+            direction="BULLISH",
+            freshness_seconds=120,
+            source="alpha_vantage",
+        )
+        await sp.publish_signal(signal)
+
+        call_kwargs = mock_kafka.send.call_args[1]
+        payload = json.loads(call_kwargs["value"].decode("utf-8"))
+        assert "instrument" in payload
+        assert "score" in payload
+        assert "direction" in payload
+        assert "freshness_seconds" in payload
+        assert "source" in payload
+
+    async def test_publish_signal_score_is_float_in_message(self, mock_kafka):
+        sp = _make_pipeline()
+        sp._producer = mock_kafka
+
+        signal = SentimentSignal(
+            instrument="GBPUSD",
+            score=0.65,
+            direction="BULLISH",
+            freshness_seconds=90,
+            source="alpha_vantage",
+        )
+        await sp.publish_signal(signal)
+
+        call_kwargs = mock_kafka.send.call_args[1]
+        payload = json.loads(call_kwargs["value"].decode("utf-8"))
+        assert isinstance(payload["score"], float)
+        assert payload["score"] == 0.65
+
+
+# ===========================================================================
+# 8. cache_signal (mock Redis / fakeredis)
+# ===========================================================================
+
+class TestCacheSignal:
+    async def test_cache_signal_stores_in_redis(self, fake_redis):
+        sp = _make_pipeline()
+        sp._redis = fake_redis
+
+        signal = SentimentSignal(
+            instrument="EURUSD",
+            score=0.4,
+            direction="BULLISH",
+            freshness_seconds=200,
+            source="alpha_vantage",
+        )
+        await sp.cache_signal(signal)
+
+        raw = await fake_redis.get("sentiment:EURUSD")
+        assert raw is not None
+
+    async def test_cache_signal_ttl_is_900s(self, fake_redis):
+        sp = _make_pipeline()
+        sp._redis = fake_redis
+
+        signal = SentimentSignal(
+            instrument="XAUUSD",
+            score=-0.2,
+            direction="BEARISH",
+            freshness_seconds=100,
+            source="reuters_rss",
+        )
+        await sp.cache_signal(signal)
+
+        ttl = await fake_redis.ttl("sentiment:XAUUSD")
+        assert TTL_SENTIMENT - 2 <= ttl <= TTL_SENTIMENT
+
+    async def test_cache_signal_value_contains_score_direction_freshness_source(
+        self, fake_redis
+    ):
+        sp = _make_pipeline()
+        sp._redis = fake_redis
+
+        signal = SentimentSignal(
+            instrument="US500",
+            score=0.1,
+            direction="NEUTRAL",
+            freshness_seconds=500,
+            source="alpha_vantage",
+        )
+        await sp.cache_signal(signal)
+
+        raw = await fake_redis.get("sentiment:US500")
+        data = json.loads(raw)
+        assert "score" in data
+        assert "direction" in data
+        assert "freshness_seconds" in data
+        assert "source" in data
+        assert data["score"] == 0.1
+        assert data["direction"] == "NEUTRAL"
+        assert data["freshness_seconds"] == 500
+        assert data["source"] == "alpha_vantage"
+
+
+# ===========================================================================
+# 9. run_once integration
+# ===========================================================================
+
+class TestRunOnce:
+    async def test_run_once_calls_compute_cache_publish(self, mock_kafka, fake_redis):
+        sp = _make_pipeline()
+        sp._producer = mock_kafka
+        sp._redis = fake_redis
+
+        expected_signal = SentimentSignal(
+            instrument="EURUSD",
+            score=0.5,
+            direction="BULLISH",
+            freshness_seconds=60,
+            source="alpha_vantage",
+        )
+        sp.compute_signal = AsyncMock(return_value=expected_signal)
+        sp.cache_signal = AsyncMock()
+        sp.publish_signal = AsyncMock()
+
+        result = await sp.run_once("EURUSD")
+
+        sp.compute_signal.assert_called_once_with("EURUSD")
+        sp.cache_signal.assert_called_once_with(expected_signal)
+        sp.publish_signal.assert_called_once_with(expected_signal)
+
+    async def test_run_once_returns_sentiment_signal(self, mock_kafka, fake_redis):
+        sp = _make_pipeline()
+        sp._producer = mock_kafka
+        sp._redis = fake_redis
+
+        expected_signal = SentimentSignal(
+            instrument="GBPUSD",
+            score=-0.3,
+            direction="BEARISH",
+            freshness_seconds=120,
+            source="reuters_rss",
+        )
+        sp.compute_signal = AsyncMock(return_value=expected_signal)
+        sp.cache_signal = AsyncMock()
+        sp.publish_signal = AsyncMock()
+
+        result = await sp.run_once("GBPUSD")
+
+        assert isinstance(result, SentimentSignal)
+        assert result.instrument == "GBPUSD"
+        assert result.score == -0.3
+
+
+# ===========================================================================
+# 10. run_all
+# ===========================================================================
+
+class TestRunAll:
+    async def test_run_all_returns_signal_for_each_instrument(
+        self, mock_kafka, fake_redis
+    ):
+        sp = _make_pipeline()
+        sp._producer = mock_kafka
+        sp._redis = fake_redis
+
+        async def _mock_run_once(instrument: str) -> SentimentSignal:
+            return SentimentSignal(
+                instrument=instrument,
+                score=0.0,
+                direction="NEUTRAL",
+                freshness_seconds=0,
+                source="mock",
+            )
+
+        sp.run_once = _mock_run_once
+
+        signals = await sp.run_all()
+        assert len(signals) == len(SUPPORTED_INSTRUMENTS)
+
+    async def test_run_all_all_signals_are_sentiment_signal_instances(
+        self, mock_kafka, fake_redis
+    ):
+        sp = _make_pipeline()
+        sp._producer = mock_kafka
+        sp._redis = fake_redis
+
+        async def _mock_run_once(instrument: str) -> SentimentSignal:
+            return SentimentSignal(
+                instrument=instrument,
+                score=0.1,
+                direction="BULLISH",
+                freshness_seconds=30,
+                source="mock",
+            )
+
+        sp.run_once = _mock_run_once
+
+        signals = await sp.run_all()
+        for signal in signals:
+            assert isinstance(signal, SentimentSignal)
+
+    async def test_run_all_instruments_match_supported_list(
+        self, mock_kafka, fake_redis
+    ):
+        sp = _make_pipeline()
+        sp._producer = mock_kafka
+        sp._redis = fake_redis
+
+        async def _mock_run_once(instrument: str) -> SentimentSignal:
+            return SentimentSignal(
+                instrument=instrument,
+                score=0.0,
+                direction="NEUTRAL",
+                freshness_seconds=0,
+                source="mock",
+            )
+
+        sp.run_once = _mock_run_once
+
+        signals = await sp.run_all()
+        returned_instruments = [s.instrument for s in signals]
+        for instrument in SUPPORTED_INSTRUMENTS:
+            assert instrument in returned_instruments

--- a/ml/inference/__init__.py
+++ b/ml/inference/__init__.py
@@ -1,0 +1,1 @@
+"""ML inference service package."""

--- a/ml/inference/main.py
+++ b/ml/inference/main.py
@@ -1,0 +1,832 @@
+"""
+ML Inference FastAPI Service.
+
+Loads trained models from the MLflow registry and exposes:
+  POST /predict  — synchronous inference for a single instrument/timeframe/candles payload
+  GET  /health   — liveness check
+
+Also runs a background Kafka consumer that:
+  - Consumes completed candles from market.candles
+  - Runs the full inference pipeline (feature extraction → regime → patterns → confluence)
+  - Publishes detected setups to setups.detected
+
+setups.detected message schema:
+  {
+    instrument, timeframe, time, regime, patterns, confidence_score,
+    htf_open, htf_high, htf_low, open_bias,
+    entry_price, sl_price, tp_price
+  }
+
+Confidence thresholds (from design.md):
+  < 0.65  → DISCARD (not published)
+  0.65–0.74 → LOG ONLY (not published)
+  ≥ 0.75  → publish to setups.detected
+
+Usage:
+    uvicorn ml.inference.main:app --host 0.0.0.0 --port 8001
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from contextlib import asynccontextmanager
+from dataclasses import asdict
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import mlflow
+import mlflow.sklearn
+import numpy as np
+from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Path setup — allow running from project root
+# ---------------------------------------------------------------------------
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+
+from ml.features.pipeline import FeaturePipeline
+from ml.features.htf_selector import get_htf_correlation, TradingStyle
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(name)s  %(levelname)s  %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+TOPIC_CANDLES = "market.candles"
+TOPIC_SETUPS = "setups.detected"
+
+CONFIDENCE_FLOOR = 0.65    # below this → discard
+CONFIDENCE_LOG_ONLY = 0.75  # [0.65, 0.75) → log only, not published
+
+REGIME_CLASSES = [
+    "TRENDING_BULLISH",
+    "TRENDING_BEARISH",
+    "RANGING",
+    "BREAKOUT",
+    "NEWS_DRIVEN",
+]
+
+PATTERN_LABELS = [
+    "BOS_CONFIRMED",
+    "CHOCH_DETECTED",
+    "BEARISH_ARRAY_REJECTION",
+    "BULLISH_ARRAY_BOUNCE",
+    "FVG_PRESENT",
+    "LIQUIDITY_SWEEP",
+    "ORDER_BLOCK",
+    "INDUCEMENT",
+]
+
+# ---------------------------------------------------------------------------
+# Pydantic schemas
+# ---------------------------------------------------------------------------
+
+
+class OHLCVCandle(BaseModel):
+    """Single OHLCV candle."""
+
+    time: str = Field(..., description="ISO-8601 UTC timestamp")
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float = 0.0
+
+
+class PredictRequest(BaseModel):
+    """Request body for POST /predict."""
+
+    instrument: str = Field(..., description="e.g. EURUSD, XAUUSD, US500")
+    timeframe: str = Field(..., description="e.g. M1, M5, M15, H1, H4, D1")
+    candles: List[OHLCVCandle] = Field(
+        ..., min_length=2, description="Chronological list of OHLCV candles"
+    )
+    # Optional reference prices for session feature computation
+    daily_open: Optional[float] = None
+    weekly_open: Optional[float] = None
+    true_day_open: Optional[float] = None
+
+
+class HTFProjections(BaseModel):
+    """HTF projection levels returned in the predict response."""
+
+    htf_timeframe: str
+    htf_open: float
+    htf_high: float
+    htf_low: float
+    open_bias: str  # BULLISH | BEARISH | NEUTRAL
+    htf_high_proximity_pct: float
+    htf_low_proximity_pct: float
+    htf_body_pct: float
+    htf_upper_wick_pct: float
+    htf_lower_wick_pct: float
+    htf_close_position: float
+
+
+class PredictResponse(BaseModel):
+    """Response body for POST /predict."""
+
+    instrument: str
+    timeframe: str
+    time: str
+    regime: str
+    patterns: List[str]
+    confidence_score: float
+    htf_projections: HTFProjections
+    # Derived trade levels (None when confidence < floor)
+    entry_price: Optional[float] = None
+    sl_price: Optional[float] = None
+    tp_price: Optional[float] = None
+
+
+class HealthResponse(BaseModel):
+    """Response body for GET /health."""
+
+    status: str
+    models_loaded: bool
+    kafka_consumer_running: bool
+
+
+# ---------------------------------------------------------------------------
+# Model registry loader
+# ---------------------------------------------------------------------------
+
+
+class ModelRegistry:
+    """
+    Loads and caches the three trained models from the MLflow registry.
+
+    Falls back to stub predictors when models are not yet registered
+    (e.g. during development before training is complete).
+    """
+
+    def __init__(self, tracking_uri: Optional[str] = None) -> None:
+        self.tracking_uri = tracking_uri or os.getenv(
+            "MLFLOW_TRACKING_URI", "http://localhost:5000"
+        )
+        mlflow.set_tracking_uri(self.tracking_uri)
+
+        self._regime_model: Any = None
+        self._pattern_model: Any = None
+        self._confluence_model: Any = None
+        self._loaded = False
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def load(self) -> None:
+        """Load all three models from the MLflow registry."""
+        self._regime_model = self._load_model("regime-classifier")
+        self._pattern_model = self._load_model("pattern-detector")
+        self._confluence_model = self._load_model("confluence-scorer")
+        self._loaded = True
+        logger.info("All models loaded (or stubs installed)")
+
+    @property
+    def loaded(self) -> bool:
+        return self._loaded
+
+    def predict_regime(self, X: np.ndarray) -> str:
+        """Return the predicted regime class label."""
+        if self._regime_model is None:
+            return "RANGING"  # stub default
+        raw = self._regime_model.predict(X)
+        idx = int(raw[0])
+        if 0 <= idx < len(REGIME_CLASSES):
+            return REGIME_CLASSES[idx]
+        # Model may return string labels directly
+        return str(raw[0])
+
+    def predict_patterns(self, X: np.ndarray, threshold: float = 0.5) -> List[str]:
+        """Return list of active pattern labels above threshold."""
+        if self._pattern_model is None:
+            return []  # stub default
+        try:
+            proba_list = self._pattern_model.predict_proba(X)
+            active = []
+            for label_idx, proba in enumerate(proba_list):
+                if proba[0, 1] >= threshold:
+                    active.append(PATTERN_LABELS[label_idx])
+            return active
+        except AttributeError:
+            # Model doesn't support predict_proba — fall back to predict
+            raw = self._pattern_model.predict(X)
+            return [
+                PATTERN_LABELS[i]
+                for i, val in enumerate(raw[0])
+                if val == 1 and i < len(PATTERN_LABELS)
+            ]
+
+    def predict_confidence(self, X: np.ndarray) -> float:
+        """Return calibrated confidence score in [0.0, 1.0]."""
+        if self._confluence_model is None:
+            return 0.0  # stub default
+        proba = self._confluence_model.predict_proba(X)
+        return float(proba[0, 1])
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _load_model(self, model_name: str) -> Optional[Any]:
+        """
+        Attempt to load the latest Production version of a registered model.
+
+        Returns None (stub) if the model is not yet registered.
+        """
+        try:
+            client = mlflow.tracking.MlflowClient()
+            versions = client.get_latest_versions(model_name, stages=["Production"])
+            if not versions:
+                # Fall back to any registered version
+                versions = client.get_latest_versions(model_name)
+            if not versions:
+                logger.warning(
+                    "Model '%s' not found in registry — using stub predictor", model_name
+                )
+                return None
+            model_uri = f"models:/{model_name}/{versions[0].version}"
+            model = mlflow.sklearn.load_model(model_uri)
+            logger.info("Loaded model '%s' version %s", model_name, versions[0].version)
+            return model
+        except Exception as exc:
+            logger.warning(
+                "Could not load model '%s': %s — using stub predictor", model_name, exc
+            )
+            return None
+
+
+# ---------------------------------------------------------------------------
+# Inference engine
+# ---------------------------------------------------------------------------
+
+
+class InferenceEngine:
+    """
+    Orchestrates feature extraction and model inference for a single setup.
+
+    Accepts a list of OHLCV candles, extracts features via FeaturePipeline,
+    runs the three models, and returns a structured prediction.
+    """
+
+    def __init__(self, registry: ModelRegistry) -> None:
+        self.registry = registry
+        self.pipeline = FeaturePipeline(enable_validation=False)
+
+    def predict(
+        self,
+        instrument: str,
+        timeframe: str,
+        candles: List[Dict[str, Any]],
+        daily_open: Optional[float] = None,
+        weekly_open: Optional[float] = None,
+        true_day_open: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """
+        Run full inference pipeline for a single instrument/timeframe/candles payload.
+
+        Args:
+            instrument: Trading instrument (e.g. "EURUSD")
+            timeframe: Candle timeframe (e.g. "M5")
+            candles: Chronological list of OHLCV dicts
+            daily_open: Optional daily open reference price
+            weekly_open: Optional weekly open reference price
+            true_day_open: Optional true day open reference price
+
+        Returns:
+            Dict with keys: regime, patterns, confidence_score, htf_projections,
+                            entry_price, sl_price, tp_price, time
+        """
+        if len(candles) < 2:
+            raise ValueError("At least 2 candles are required for inference")
+
+        # Determine HTF timeframe using the 3-tier correlation
+        htf_timeframe = self._get_htf_timeframe(timeframe)
+
+        # Use the most recent candle as the HTF candle proxy when no separate
+        # HTF feed is available (the pipeline will use it for HTF projections)
+        htf_candle = self._build_htf_candle(candles, htf_timeframe)
+
+        # Extract features
+        features_df = self.pipeline.transform(
+            candles=candles,
+            htf_candle=htf_candle,
+            instrument=instrument,
+            htf_timeframe=htf_timeframe,
+            daily_open=daily_open,
+            weekly_open=weekly_open,
+            true_day_open=true_day_open,
+        )
+
+        # Encode for sklearn models
+        X = self._encode_features(features_df)
+
+        # Run models
+        regime = self.registry.predict_regime(X)
+        patterns = self.registry.predict_patterns(X)
+        confidence_score = self.registry.predict_confidence(X)
+
+        # Extract HTF projection values from features
+        htf_proj = self._extract_htf_projections(features_df, htf_timeframe)
+
+        # Derive trade levels from the last candle and HTF levels
+        current_candle = candles[-1]
+        entry_price, sl_price, tp_price = self._derive_trade_levels(
+            current_candle=current_candle,
+            htf_proj=htf_proj,
+            confidence_score=confidence_score,
+        )
+
+        # Timestamp from the most recent candle
+        time_str = str(current_candle.get("time", datetime.now(timezone.utc).isoformat()))
+
+        return {
+            "time": time_str,
+            "regime": regime,
+            "patterns": patterns,
+            "confidence_score": confidence_score,
+            "htf_projections": htf_proj,
+            "entry_price": entry_price,
+            "sl_price": sl_price,
+            "tp_price": tp_price,
+        }
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _get_htf_timeframe(self, timeframe: str) -> str:
+        """Derive the HTF timeframe using the INTRADAY_STANDARD 3-tier correlation."""
+        try:
+            bias_tf, structure_tf, entry_tf = get_htf_correlation(
+                timeframe, TradingStyle.INTRADAY_STANDARD
+            )
+            return bias_tf
+        except (ValueError, KeyError):
+            # Fallback mapping for timeframes not in the selector
+            _fallback = {
+                "M1": "M5", "M3": "M15", "M5": "M15",
+                "M15": "H1", "M30": "H4", "H1": "H4",
+                "H4": "D1", "D1": "W1", "W1": "D1",
+            }
+            return _fallback.get(timeframe, "H1")
+
+    def _build_htf_candle(
+        self, candles: List[Dict[str, Any]], htf_timeframe: str
+    ) -> Dict[str, Any]:
+        """
+        Build a synthetic HTF candle from the provided candle list.
+
+        In production the HTF candle would be fetched from TimescaleDB.
+        Here we aggregate the provided candles into a single OHLCV candle
+        to represent the HTF period.
+        """
+        opens = [float(c["open"]) for c in candles]
+        highs = [float(c["high"]) for c in candles]
+        lows = [float(c["low"]) for c in candles]
+        closes = [float(c["close"]) for c in candles]
+        volumes = [float(c.get("volume", 0)) for c in candles]
+
+        return {
+            "time": candles[0]["time"],
+            "open": opens[0],
+            "high": max(highs),
+            "low": min(lows),
+            "close": closes[-1],
+            "volume": sum(volumes),
+        }
+
+    def _encode_features(self, features_df) -> np.ndarray:
+        """Encode the feature DataFrame to a numeric numpy array for sklearn."""
+        import pandas as pd
+
+        df = features_df.copy()
+
+        # Encode string/bool columns
+        bias_map = {"BULLISH": 1, "NEUTRAL": 0, "BEARISH": -1}
+        pos_map = {"ABOVE": 1, "AT": 0, "BELOW": -1}
+
+        for col in df.columns:
+            if df[col].dtype == bool:
+                df[col] = df[col].astype(int)
+            elif col in ("htf_open_bias", "htf_trend_bias"):
+                df[col] = df[col].map(bias_map).fillna(0)
+            elif col in ("price_vs_daily_open", "price_vs_weekly_open", "price_vs_true_day_open"):
+                df[col] = df[col].map(pos_map).fillna(0)
+            elif df[col].dtype == object:
+                df[col] = pd.Categorical(df[col]).codes
+
+        return df.values.astype(float)
+
+    def _extract_htf_projections(
+        self, features_df, htf_timeframe: str
+    ) -> Dict[str, Any]:
+        """Extract HTF projection values from the feature DataFrame."""
+        row = features_df.iloc[0]
+        return {
+            "htf_timeframe": htf_timeframe,
+            "htf_open": float(row.get("htf_open", 0.0)),
+            "htf_high": float(row.get("htf_high", 0.0)),
+            "htf_low": float(row.get("htf_low", 0.0)),
+            "open_bias": str(row.get("htf_open_bias", "NEUTRAL")),
+            "htf_high_proximity_pct": float(row.get("htf_high_proximity_pct", 50.0)),
+            "htf_low_proximity_pct": float(row.get("htf_low_proximity_pct", 50.0)),
+            "htf_body_pct": float(row.get("htf_body_pct", 0.0)),
+            "htf_upper_wick_pct": float(row.get("htf_upper_wick_pct", 0.0)),
+            "htf_lower_wick_pct": float(row.get("htf_lower_wick_pct", 0.0)),
+            "htf_close_position": float(row.get("htf_close_position", 50.0)),
+        }
+
+    def _derive_trade_levels(
+        self,
+        current_candle: Dict[str, Any],
+        htf_proj: Dict[str, Any],
+        confidence_score: float,
+    ) -> tuple[Optional[float], Optional[float], Optional[float]]:
+        """
+        Derive entry, SL, and TP prices from the current candle and HTF levels.
+
+        Returns (None, None, None) when confidence is below the floor.
+
+        Logic:
+          - Bullish: entry = current close, SL = HTF low, TP = HTF high
+          - Bearish: entry = current close, SL = HTF high, TP = HTF low
+          - Neutral: no trade levels
+        """
+        if confidence_score < CONFIDENCE_FLOOR:
+            return None, None, None
+
+        close = float(current_candle["close"])
+        htf_high = htf_proj["htf_high"]
+        htf_low = htf_proj["htf_low"]
+        open_bias = htf_proj["open_bias"]
+
+        if open_bias == "BULLISH":
+            entry_price = close
+            sl_price = htf_low
+            tp_price = htf_high
+        elif open_bias == "BEARISH":
+            entry_price = close
+            sl_price = htf_high
+            tp_price = htf_low
+        else:
+            return None, None, None
+
+        # Sanity check: SL must differ from entry
+        if abs(entry_price - sl_price) < 1e-8:
+            return None, None, None
+
+        return entry_price, sl_price, tp_price
+
+
+# ---------------------------------------------------------------------------
+# Kafka consumer
+# ---------------------------------------------------------------------------
+
+
+class SetupPublisher:
+    """Publishes detected setups to the setups.detected Kafka topic."""
+
+    def __init__(self, bootstrap_servers: str) -> None:
+        self.bootstrap_servers = bootstrap_servers
+        self._producer: Optional[AIOKafkaProducer] = None
+
+    async def start(self) -> None:
+        self._producer = AIOKafkaProducer(bootstrap_servers=self.bootstrap_servers)
+        await self._producer.start()
+
+    async def stop(self) -> None:
+        if self._producer:
+            await self._producer.flush()
+            await self._producer.stop()
+
+    async def publish(self, setup: Dict[str, Any]) -> None:
+        if self._producer is None:
+            return
+        key = f"{setup['instrument']}:{setup['timeframe']}".encode()
+        value = json.dumps(setup, default=str).encode()
+        await self._producer.send(TOPIC_SETUPS, key=key, value=value)
+
+
+class CandleConsumer:
+    """
+    Kafka consumer that reads from market.candles and runs inference.
+
+    For each completed candle:
+      1. Accumulate a rolling window of candles per instrument/timeframe
+      2. Run InferenceEngine.predict()
+      3. If confidence >= 0.75, publish to setups.detected
+    """
+
+    # Rolling window size per instrument:timeframe key
+    WINDOW_SIZE = 50
+
+    def __init__(
+        self,
+        bootstrap_servers: str,
+        engine: InferenceEngine,
+        publisher: SetupPublisher,
+        group_id: str = "ml-inference-service",
+    ) -> None:
+        self.bootstrap_servers = bootstrap_servers
+        self.engine = engine
+        self.publisher = publisher
+        self.group_id = group_id
+        self._consumer: Optional[AIOKafkaConsumer] = None
+        self._running = False
+        # Rolling candle windows: key = "instrument:timeframe"
+        self._windows: Dict[str, List[Dict[str, Any]]] = {}
+
+    @property
+    def running(self) -> bool:
+        return self._running
+
+    async def start(self) -> None:
+        self._consumer = AIOKafkaConsumer(
+            TOPIC_CANDLES,
+            bootstrap_servers=self.bootstrap_servers,
+            group_id=self.group_id,
+            value_deserializer=lambda v: json.loads(v.decode()),
+            auto_offset_reset="latest",
+        )
+        await self._consumer.start()
+        self._running = True
+        logger.info("Kafka consumer started — listening on %s", TOPIC_CANDLES)
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._consumer:
+            await self._consumer.stop()
+
+    async def run(self) -> None:
+        """Main consume loop — runs until stop() is called."""
+        if self._consumer is None:
+            raise RuntimeError("Consumer not started — call start() first")
+
+        async for msg in self._consumer:
+            if not self._running:
+                break
+            try:
+                await self._handle_message(msg.value)
+            except Exception as exc:
+                logger.error("Error handling candle message: %s", exc, exc_info=True)
+
+    async def _handle_message(self, candle: Dict[str, Any]) -> None:
+        """Process a single candle message."""
+        # Only process completed candles
+        if not candle.get("complete", False):
+            return
+
+        instrument = candle.get("instrument", "")
+        timeframe = candle.get("timeframe", "")
+        if not instrument or not timeframe:
+            return
+
+        key = f"{instrument}:{timeframe}"
+
+        # Maintain rolling window
+        window = self._windows.setdefault(key, [])
+        window.append(candle)
+        if len(window) > self.WINDOW_SIZE:
+            window.pop(0)
+
+        # Need at least 2 candles for inference
+        if len(window) < 2:
+            return
+
+        # Run inference
+        result = self.engine.predict(
+            instrument=instrument,
+            timeframe=timeframe,
+            candles=window,
+        )
+
+        confidence = result["confidence_score"]
+
+        if confidence < CONFIDENCE_FLOOR:
+            logger.debug(
+                "Setup discarded (confidence=%.3f < %.2f): %s %s",
+                confidence, CONFIDENCE_FLOOR, instrument, timeframe,
+            )
+            return
+
+        if confidence < CONFIDENCE_LOG_ONLY:
+            logger.info(
+                "Setup logged only (confidence=%.3f): %s %s — regime=%s patterns=%s",
+                confidence, instrument, timeframe, result["regime"], result["patterns"],
+            )
+            return
+
+        # Build setups.detected message
+        htf = result["htf_projections"]
+        setup_msg: Dict[str, Any] = {
+            "instrument": instrument,
+            "timeframe": timeframe,
+            "time": result["time"],
+            "regime": result["regime"],
+            "patterns": result["patterns"],
+            "confidence_score": confidence,
+            "htf_open": htf["htf_open"],
+            "htf_high": htf["htf_high"],
+            "htf_low": htf["htf_low"],
+            "open_bias": htf["open_bias"],
+            "entry_price": result["entry_price"],
+            "sl_price": result["sl_price"],
+            "tp_price": result["tp_price"],
+        }
+
+        await self.publisher.publish(setup_msg)
+        logger.info(
+            "Setup published (confidence=%.3f): %s %s regime=%s patterns=%s",
+            confidence, instrument, timeframe, result["regime"], result["patterns"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Application factory
+# ---------------------------------------------------------------------------
+
+
+def create_app(
+    registry: Optional[ModelRegistry] = None,
+    consumer: Optional[CandleConsumer] = None,
+    skip_kafka: bool = False,
+) -> FastAPI:
+    """
+    Create and configure the FastAPI application.
+
+    Args:
+        registry: Pre-built ModelRegistry (injected for testing)
+        consumer: Pre-built CandleConsumer (injected for testing)
+        skip_kafka: When True, skip Kafka consumer/producer startup entirely.
+                    Automatically set to True when a registry is injected (test mode).
+
+    Returns:
+        Configured FastAPI application
+    """
+    _registry = registry or ModelRegistry()
+    _consumer_ref: Dict[str, Any] = {"instance": consumer}
+    _consumer_task: Dict[str, Any] = {"task": None}
+    # Skip Kafka when a registry is injected (test mode) or explicitly requested
+    _skip_kafka = skip_kafka or (registry is not None and consumer is None)
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        # Startup — only load models if not already loaded (e.g. injected in tests)
+        if not _registry.loaded:
+            _registry.load()
+
+        bootstrap = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+
+        if not _skip_kafka and _consumer_ref["instance"] is None:
+            engine = InferenceEngine(_registry)
+            publisher = SetupPublisher(bootstrap)
+            try:
+                await asyncio.wait_for(publisher.start(), timeout=5.0)
+            except (Exception, asyncio.TimeoutError) as exc:
+                logger.warning("Kafka publisher unavailable: %s", exc)
+
+            _consumer_ref["instance"] = CandleConsumer(
+                bootstrap_servers=bootstrap,
+                engine=engine,
+                publisher=publisher,
+            )
+            try:
+                await asyncio.wait_for(_consumer_ref["instance"].start(), timeout=5.0)
+                _consumer_task["task"] = asyncio.create_task(
+                    _consumer_ref["instance"].run()
+                )
+            except (Exception, asyncio.TimeoutError) as exc:
+                logger.warning("Kafka consumer unavailable: %s", exc)
+
+        yield
+
+        # Shutdown
+        if _consumer_task["task"]:
+            _consumer_task["task"].cancel()
+            try:
+                await _consumer_task["task"]
+            except asyncio.CancelledError:
+                pass
+        if _consumer_ref["instance"]:
+            try:
+                await _consumer_ref["instance"].stop()
+            except Exception:
+                pass
+
+    app = FastAPI(
+        title="AgentICTrader ML Inference Service",
+        description=(
+            "Loads regime-classifier, pattern-detector, and confluence-scorer "
+            "from MLflow and exposes a /predict endpoint. Also consumes "
+            "market.candles and publishes to setups.detected."
+        ),
+        version="1.0.0",
+        lifespan=lifespan,
+    )
+
+    # ------------------------------------------------------------------
+    # Routes
+    # ------------------------------------------------------------------
+
+    @app.get("/health", response_model=HealthResponse)
+    async def health() -> HealthResponse:
+        """Liveness check."""
+        consumer_running = (
+            _consumer_ref["instance"] is not None
+            and _consumer_ref["instance"].running
+        )
+        return HealthResponse(
+            status="ok",
+            models_loaded=_registry.loaded,
+            kafka_consumer_running=consumer_running,
+        )
+
+    @app.post("/predict", response_model=PredictResponse)
+    async def predict(request: PredictRequest) -> PredictResponse:
+        """
+        Run ML inference for a given instrument/timeframe/candles payload.
+
+        Returns regime classification, detected patterns, confidence score,
+        HTF projection levels, and derived trade levels.
+        """
+        if len(request.candles) < 2:
+            raise HTTPException(
+                status_code=422,
+                detail="At least 2 candles are required for inference",
+            )
+
+        candles_dicts = [c.model_dump() for c in request.candles]
+
+        engine = InferenceEngine(_registry)
+        try:
+            result = engine.predict(
+                instrument=request.instrument,
+                timeframe=request.timeframe,
+                candles=candles_dicts,
+                daily_open=request.daily_open,
+                weekly_open=request.weekly_open,
+                true_day_open=request.true_day_open,
+            )
+        except Exception as exc:
+            logger.error("Inference error: %s", exc, exc_info=True)
+            raise HTTPException(status_code=500, detail=f"Inference failed: {exc}")
+
+        htf = result["htf_projections"]
+        return PredictResponse(
+            instrument=request.instrument,
+            timeframe=request.timeframe,
+            time=result["time"],
+            regime=result["regime"],
+            patterns=result["patterns"],
+            confidence_score=result["confidence_score"],
+            htf_projections=HTFProjections(
+                htf_timeframe=htf["htf_timeframe"],
+                htf_open=htf["htf_open"],
+                htf_high=htf["htf_high"],
+                htf_low=htf["htf_low"],
+                open_bias=htf["open_bias"],
+                htf_high_proximity_pct=htf["htf_high_proximity_pct"],
+                htf_low_proximity_pct=htf["htf_low_proximity_pct"],
+                htf_body_pct=htf["htf_body_pct"],
+                htf_upper_wick_pct=htf["htf_upper_wick_pct"],
+                htf_lower_wick_pct=htf["htf_lower_wick_pct"],
+                htf_close_position=htf["htf_close_position"],
+            ),
+            entry_price=result["entry_price"],
+            sl_price=result["sl_price"],
+            tp_price=result["tp_price"],
+        )
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+app = create_app()
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(
+        "ml.inference.main:app",
+        host="0.0.0.0",
+        port=int(os.getenv("INFERENCE_PORT", "8001")),
+        reload=False,
+    )

--- a/services/nlp/__init__.py
+++ b/services/nlp/__init__.py
@@ -1,0 +1,37 @@
+"""
+services/nlp — NLP and sentiment analysis package for AgentICTrader.
+
+Provides:
+- FinBERT-based sentiment classification for financial news
+- LLM macro event summariser and trade reasoning generator (Claude / template fallback)
+- Economic calendar blackout monitor
+"""
+from services.nlp.sentiment_pipeline import (
+    SentimentPipeline,
+    SentimentSignal,
+    NewsArticle,
+    SUPPORTED_INSTRUMENTS,
+    INSTRUMENT_KEYWORDS,
+    TOPIC_SENTIMENT,
+    FINBERT_MODEL,
+    TTL_SENTIMENT,
+)
+from services.nlp.llm_service import (
+    LLMService,
+    CLAUDE_MODEL,
+)
+
+__all__ = [
+    # Sentiment pipeline
+    "SentimentPipeline",
+    "SentimentSignal",
+    "NewsArticle",
+    "SUPPORTED_INSTRUMENTS",
+    "INSTRUMENT_KEYWORDS",
+    "TOPIC_SENTIMENT",
+    "FINBERT_MODEL",
+    "TTL_SENTIMENT",
+    # LLM service
+    "LLMService",
+    "CLAUDE_MODEL",
+]

--- a/services/nlp/calendar_monitor.py
+++ b/services/nlp/calendar_monitor.py
@@ -1,0 +1,392 @@
+"""
+Economic calendar blackout monitor for AgentICTrader.
+
+Polls TimescaleDB economic_events every 60s.
+Detects HIGH impact events within ±15 min window for each instrument's currency.
+Publishes blackout state to Redis: key blackout:{instrument} → {active, event_name, minutes_remaining}
+
+Redis keys:
+  blackout:{instrument} — blackout state (TTL 120s)
+
+Usage::
+
+    monitor = CalendarMonitor()
+    await monitor.connect()
+    await monitor.run()          # continuous loop
+    await monitor.close()
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+import asyncpg
+import redis.asyncio as aioredis
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+BLACKOUT_WINDOW_MINUTES: int = 15       # ±15 min around HIGH impact events
+POLL_INTERVAL_SECONDS: int = 60         # poll TimescaleDB every 60s
+TTL_BLACKOUT: int = 120                 # Redis TTL for blackout keys (2× poll interval)
+
+# Instrument → list of currencies to monitor for blackout.
+# Crypto instruments have no currency blackout.
+INSTRUMENT_CURRENCIES: dict[str, list[str]] = {
+    "EURUSD": ["EUR", "USD"],
+    "GBPUSD": ["GBP", "USD"],
+    "US500":  ["USD"],
+    "US30":   ["USD"],
+    "XAUUSD": ["XAU", "USD"],
+    "BTCUSD": [],   # crypto — no currency blackout
+    "ETHUSD": [],   # crypto — no currency blackout
+}
+
+SUPPORTED_INSTRUMENTS: list[str] = list(INSTRUMENT_CURRENCIES.keys())
+
+
+# ---------------------------------------------------------------------------
+# Key builder
+# ---------------------------------------------------------------------------
+
+def blackout_key(instrument: str) -> str:
+    """Return the Redis key for the blackout state of *instrument*.
+
+    Args:
+        instrument: e.g. ``"EURUSD"``
+
+    Returns:
+        ``"blackout:EURUSD"``
+    """
+    return f"blackout:{instrument}"
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class BlackoutState:
+    """Blackout state for a single instrument at a point in time.
+
+    Attributes:
+        instrument:        Instrument symbol, e.g. ``"EURUSD"``.
+        active:            ``True`` when a HIGH impact event is within ±15 min.
+        event_name:        Name of the triggering event; empty string when inactive.
+        minutes_remaining: Signed minutes to/from the nearest event.
+                           Positive = event in the future.
+                           Negative = event already passed.
+                           Zero when inactive.
+    """
+    instrument: str
+    active: bool
+    event_name: str
+    minutes_remaining: float
+
+
+# ---------------------------------------------------------------------------
+# CalendarMonitor
+# ---------------------------------------------------------------------------
+
+class CalendarMonitor:
+    """Polls TimescaleDB for HIGH impact economic events and publishes blackout
+    state to Redis for every supported instrument.
+
+    Lifecycle::
+
+        monitor = CalendarMonitor()
+        await monitor.connect()
+        try:
+            await monitor.run()          # blocks until cancelled
+        finally:
+            await monitor.close()
+    """
+
+    def __init__(
+        self,
+        db_host: str = "localhost",
+        db_port: int = 5432,
+        db_name: str = "agentictrader",
+        db_user: str = "agentictrader",
+        db_password: str = "changeme",
+        redis_host: str = "localhost",
+        redis_port: int = 6379,
+        poll_interval: int = POLL_INTERVAL_SECONDS,
+    ) -> None:
+        self._db_host = db_host
+        self._db_port = db_port
+        self._db_name = db_name
+        self._db_user = db_user
+        self._db_password = db_password
+        self._redis_host = redis_host
+        self._redis_port = redis_port
+        self._poll_interval = poll_interval
+
+        self._pool: Optional[asyncpg.Pool] = None
+        self._redis: Optional[aioredis.Redis] = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> None:
+        """Create asyncpg connection pool and Redis connection."""
+        self._pool = await asyncpg.create_pool(
+            host=self._db_host,
+            port=self._db_port,
+            database=self._db_name,
+            user=self._db_user,
+            password=self._db_password,
+        )
+        self._redis = aioredis.Redis(
+            host=self._redis_host,
+            port=self._redis_port,
+            decode_responses=True,
+        )
+        logger.info(
+            "CalendarMonitor connected (db=%s:%s/%s, redis=%s:%s)",
+            self._db_host,
+            self._db_port,
+            self._db_name,
+            self._redis_host,
+            self._redis_port,
+        )
+
+    async def close(self) -> None:
+        """Close asyncpg pool and Redis connection."""
+        if self._pool is not None:
+            try:
+                await self._pool.close()
+            except Exception:
+                pass
+            finally:
+                self._pool = None
+
+        if self._redis is not None:
+            try:
+                await self._redis.aclose()
+            except Exception:
+                pass
+            finally:
+                self._redis = None
+
+        logger.info("CalendarMonitor closed")
+
+    # ------------------------------------------------------------------
+    # Database query
+    # ------------------------------------------------------------------
+
+    async def fetch_upcoming_high_impact_events(
+        self, currencies: list[str]
+    ) -> list[dict]:
+        """Query TimescaleDB for HIGH impact events within ±15 min of now.
+
+        Only events whose ``currency`` is in *currencies* are returned.
+        Results are ordered by proximity to now (nearest first).
+
+        Args:
+            currencies: List of currency codes to filter on, e.g. ``["EUR", "USD"]``.
+
+        Returns:
+            List of dicts with keys ``event_time``, ``currency``, ``event_name``.
+            Returns an empty list when *currencies* is empty.
+        """
+        if not currencies:
+            return []
+
+        sql = """
+            SELECT event_time, currency, event_name
+            FROM economic_events
+            WHERE impact = 'HIGH'
+              AND currency = ANY($1)
+              AND event_time BETWEEN NOW() - INTERVAL '15 minutes'
+                                 AND NOW() + INTERVAL '15 minutes'
+            ORDER BY ABS(EXTRACT(EPOCH FROM (event_time - NOW())))
+        """
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(sql, currencies)
+
+        return [dict(row) for row in rows]
+
+    # ------------------------------------------------------------------
+    # Blackout computation
+    # ------------------------------------------------------------------
+
+    def compute_blackout_state(
+        self,
+        instrument: str,
+        events: list[dict],
+        now: datetime,
+    ) -> BlackoutState:
+        """Compute the BlackoutState for *instrument* given a list of HIGH impact events.
+
+        The events list is assumed to already be filtered to the ±15 min window
+        (as returned by :meth:`fetch_upcoming_high_impact_events`).
+
+        Args:
+            instrument: Instrument symbol, e.g. ``"EURUSD"``.
+            events:     List of event dicts with at least ``event_time`` and
+                        ``event_name`` keys.
+            now:        Reference timestamp (timezone-aware UTC).
+
+        Returns:
+            :class:`BlackoutState` with:
+            - ``active=False``, ``event_name=""``, ``minutes_remaining=0.0``
+              when *events* is empty.
+            - ``active=True`` and details of the nearest event otherwise.
+        """
+        if not events:
+            return BlackoutState(
+                instrument=instrument,
+                active=False,
+                event_name="",
+                minutes_remaining=0.0,
+            )
+
+        # Find the nearest event (smallest absolute minutes_remaining)
+        def _minutes(event: dict) -> float:
+            event_time: datetime = event["event_time"]
+            # Ensure both datetimes are timezone-aware for subtraction
+            if event_time.tzinfo is None:
+                event_time = event_time.replace(tzinfo=timezone.utc)
+            return (event_time - now).total_seconds() / 60.0
+
+        # Safety guard: only consider events within the ±BLACKOUT_WINDOW_MINUTES window
+        window_events = [e for e in events if abs(_minutes(e)) <= BLACKOUT_WINDOW_MINUTES]
+
+        if not window_events:
+            return BlackoutState(
+                instrument=instrument,
+                active=False,
+                event_name="",
+                minutes_remaining=0.0,
+            )
+
+        nearest = min(window_events, key=lambda e: abs(_minutes(e)))
+        mins = _minutes(nearest)
+
+        return BlackoutState(
+            instrument=instrument,
+            active=True,
+            event_name=nearest["event_name"],
+            minutes_remaining=mins,
+        )
+
+    # ------------------------------------------------------------------
+    # Redis publishing
+    # ------------------------------------------------------------------
+
+    async def publish_blackout_state(self, state: BlackoutState) -> None:
+        """Write *state* to Redis.
+
+        Key:   ``blackout:{instrument}``
+        Value: JSON ``{"active": bool, "event_name": str, "minutes_remaining": float}``
+        TTL:   :data:`TTL_BLACKOUT` seconds (120 s)
+
+        Args:
+            state: The :class:`BlackoutState` to publish.
+        """
+        key = blackout_key(state.instrument)
+        value = json.dumps(
+            {
+                "active": state.active,
+                "event_name": state.event_name,
+                "minutes_remaining": state.minutes_remaining,
+            }
+        )
+        await self._redis.set(key, value, ex=TTL_BLACKOUT)
+        logger.debug(
+            "Published blackout state for %s: active=%s (TTL=%ss)",
+            state.instrument,
+            state.active,
+            TTL_BLACKOUT,
+        )
+
+    # ------------------------------------------------------------------
+    # Per-instrument pipeline
+    # ------------------------------------------------------------------
+
+    async def check_instrument(
+        self, instrument: str, now: datetime
+    ) -> BlackoutState:
+        """Run the full blackout pipeline for a single *instrument*.
+
+        Steps:
+        1. Look up the currencies for *instrument*.
+        2. If no currencies → publish inactive state and return.
+        3. Fetch HIGH impact events within ±15 min for those currencies.
+        4. Compute the :class:`BlackoutState`.
+        5. Publish the state to Redis.
+        6. Return the state.
+
+        Args:
+            instrument: Instrument symbol, e.g. ``"EURUSD"``.
+            now:        Reference timestamp (timezone-aware UTC).
+
+        Returns:
+            The computed :class:`BlackoutState`.
+        """
+        currencies = INSTRUMENT_CURRENCIES.get(instrument, [])
+
+        if not currencies:
+            # Crypto instruments — no currency blackout
+            state = BlackoutState(
+                instrument=instrument,
+                active=False,
+                event_name="",
+                minutes_remaining=0.0,
+            )
+            await self.publish_blackout_state(state)
+            return state
+
+        events = await self.fetch_upcoming_high_impact_events(currencies)
+        state = self.compute_blackout_state(instrument, events, now)
+        await self.publish_blackout_state(state)
+        return state
+
+    # ------------------------------------------------------------------
+    # Poll cycle
+    # ------------------------------------------------------------------
+
+    async def run_once(self) -> list[BlackoutState]:
+        """Run one poll cycle: check all :data:`SUPPORTED_INSTRUMENTS`.
+
+        Returns:
+            List of :class:`BlackoutState` for every supported instrument.
+        """
+        now = datetime.now(tz=timezone.utc)
+        states: list[BlackoutState] = []
+        for instrument in SUPPORTED_INSTRUMENTS:
+            state = await self.check_instrument(instrument, now)
+            states.append(state)
+        return states
+
+    # ------------------------------------------------------------------
+    # Continuous loop
+    # ------------------------------------------------------------------
+
+    async def run(self) -> None:
+        """Continuous polling loop: call :meth:`run_once` every *poll_interval* seconds.
+
+        Runs until cancelled.  :exc:`asyncio.CancelledError` is caught and the
+        loop exits cleanly.
+        """
+        logger.info(
+            "CalendarMonitor starting poll loop (interval=%ss)", self._poll_interval
+        )
+        try:
+            while True:
+                try:
+                    await self.run_once()
+                except Exception as exc:
+                    logger.error("CalendarMonitor poll error: %s", exc, exc_info=True)
+                await asyncio.sleep(self._poll_interval)
+        except asyncio.CancelledError:
+            logger.info("CalendarMonitor poll loop cancelled — shutting down")

--- a/services/nlp/llm_service.py
+++ b/services/nlp/llm_service.py
@@ -1,0 +1,491 @@
+"""
+LLM macro event summariser and trade reasoning generator for AgentICTrader.
+
+Provides two main capabilities:
+1. summarise_macro_event(event) — summarises a macro economic event using Claude API
+2. generate_trade_reasoning(setup) — generates structured trade reasoning using the
+   3-question narrative framework (where has price come from / where is it now /
+   where is it likely to go)
+
+Claude (Anthropic) is the primary LLM. If the Claude API is unavailable, both
+functions fall back to template-based reasoning using get_narrative_context().
+
+Usage::
+
+    service = LLMService(anthropic_api_key="YOUR_KEY")
+    summary = await service.summarise_macro_event(event)
+    reasoning = await service.generate_trade_reasoning(setup)
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Optional Anthropic import — graceful degradation if not installed
+# ---------------------------------------------------------------------------
+try:
+    import anthropic
+
+    _ANTHROPIC_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _ANTHROPIC_AVAILABLE = False
+    anthropic = None  # type: ignore[assignment]
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CLAUDE_MODEL = "claude-3-5-sonnet-20241022"
+
+# Narrative phase → human-readable description
+_PHASE_DESCRIPTIONS: dict[str, str] = {
+    "ACCUMULATION": "accumulation phase (liquidity building)",
+    "MANIPULATION": "manipulation phase (stop hunt / liquidity sweep)",
+    "EXPANSION": "expansion/delivery phase",
+    "DISTRIBUTION": "distribution phase (position squaring)",
+    "TRANSITION": "transition phase (NY midnight reference)",
+    "OFF": "off-hours",
+}
+
+# Time window → human-readable label
+_WINDOW_LABELS: dict[str, str] = {
+    "ASIAN_RANGE": "Asian Range (20:00–22:00 NY)",
+    "TRUE_DAY_OPEN": "True Day Open (00:00–01:00 NY)",
+    "LONDON_KILLZONE": "London Killzone (02:00–05:00 NY)",
+    "LONDON_SILVER_BULLET": "London Silver Bullet (03:00–04:00 NY)",
+    "NY_AM_KILLZONE": "NY AM Killzone (07:00–10:00 NY)",
+    "NY_AM_SILVER_BULLET": "NY AM Silver Bullet (10:00–11:00 NY)",
+    "LONDON_CLOSE": "London Close (10:00–12:00 NY)",
+    "NY_PM_KILLZONE": "NY PM Killzone (13:30–16:00 NY)",
+    "NY_PM_SILVER_BULLET": "NY PM Silver Bullet (14:00–15:00 NY)",
+    "NEWS_WINDOW": "News Window (08:00–09:00 NY)",
+    "DAILY_CLOSE": "Daily Close (17:00–18:00 NY)",
+    "OFF_HOURS": "Off-Hours",
+}
+
+
+# ---------------------------------------------------------------------------
+# LLMService
+# ---------------------------------------------------------------------------
+
+
+class LLMService:
+    """
+    LLM-powered macro event summariser and trade reasoning generator.
+
+    Uses Claude (Anthropic) as the primary LLM with automatic fallback to
+    template-based reasoning when the API is unavailable or returns an error.
+
+    Args:
+        anthropic_api_key: Anthropic API key. If empty or None, the service
+            operates in template-only mode (no Claude calls).
+        claude_model: Claude model identifier to use.
+        max_tokens: Maximum tokens for Claude responses.
+    """
+
+    def __init__(
+        self,
+        anthropic_api_key: str = "",
+        claude_model: str = CLAUDE_MODEL,
+        max_tokens: int = 512,
+    ) -> None:
+        self._api_key = anthropic_api_key
+        self._claude_model = claude_model
+        self._max_tokens = max_tokens
+        self._client: Optional[object] = None
+
+        if _ANTHROPIC_AVAILABLE and anthropic_api_key:
+            try:
+                self._client = anthropic.Anthropic(api_key=anthropic_api_key)
+            except Exception as exc:  # pragma: no cover
+                logger.warning("Failed to initialise Anthropic client: %s", exc)
+                self._client = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def summarise_macro_event(self, event: dict) -> str:
+        """Summarise a macro economic event in plain English.
+
+        Attempts to use Claude to produce a concise, trader-focused summary.
+        Falls back to a template-based summary if Claude is unavailable.
+
+        Args:
+            event: Dict with at least ``event_name`` and optionally
+                ``currency``, ``impact``, ``actual``, ``forecast``,
+                ``previous``, ``event_time``.
+
+        Returns:
+            A plain-English summary string (never empty).
+        """
+        if self._client is not None:
+            try:
+                return await self._summarise_with_claude(event)
+            except Exception as exc:
+                logger.warning(
+                    "Claude summarise_macro_event failed (%s) — using template fallback",
+                    exc,
+                )
+
+        return self._summarise_template(event)
+
+    async def generate_trade_reasoning(self, setup: dict) -> str:
+        """Generate structured trade reasoning for a detected setup.
+
+        The reasoning is structured around the 3-question narrative framework:
+        1. Where has price come from? (HTF context, PD arrays swept/respected)
+        2. Where is it now? (time window, price vs reference opens)
+        3. Where is it likely to go? (nearest liquidity pool or imbalance)
+
+        Attempts to use Claude for richer, context-aware prose. Falls back to
+        template-based reasoning (via :func:`get_narrative_context`) if Claude
+        is unavailable.
+
+        Args:
+            setup: Dict containing setup context. Expected keys (all optional
+                but used when present):
+
+                - ``instrument`` (str)
+                - ``direction`` (str): "BULLISH" | "BEARISH"
+                - ``htf_open_bias`` (str): "BULLISH" | "BEARISH" | "NEUTRAL"
+                - ``htf_open`` (float)
+                - ``htf_high`` (float)
+                - ``htf_low`` (float)
+                - ``time_window`` (str)
+                - ``narrative_phase`` (str)
+                - ``price_vs_daily_open`` (str): "ABOVE" | "BELOW" | "AT"
+                - ``price_vs_weekly_open`` (str)
+                - ``price_vs_true_day_open`` (str)
+                - ``patterns`` (list[str])
+                - ``confidence_score`` (float)
+                - ``entry_price`` (float)
+                - ``sl_price`` (float)
+                - ``tp_price`` (float)
+                - ``swing_high`` (float)
+                - ``swing_low`` (float)
+                - ``fvg_present`` (bool)
+                - ``session_sweep_time`` (str): e.g. "03:15 NY"
+                - ``session_sweep_level`` (str): e.g. "Asian range low"
+
+        Returns:
+            A structured reasoning string (never empty).
+        """
+        if self._client is not None:
+            try:
+                return await self._reason_with_claude(setup)
+            except Exception as exc:
+                logger.warning(
+                    "Claude generate_trade_reasoning failed (%s) — using template fallback",
+                    exc,
+                )
+
+        return self._reason_template(setup)
+
+    # ------------------------------------------------------------------
+    # Claude implementations
+    # ------------------------------------------------------------------
+
+    async def _summarise_with_claude(self, event: dict) -> str:
+        """Call Claude to summarise a macro event."""
+        event_name = event.get("event_name", "Unknown event")
+        currency = event.get("currency", "")
+        impact = event.get("impact", "")
+        actual = event.get("actual", "N/A")
+        forecast = event.get("forecast", "N/A")
+        previous = event.get("previous", "N/A")
+        event_time = event.get("event_time", "")
+
+        prompt = (
+            f"You are a professional FX/indices trader. Summarise the following "
+            f"macro economic event in 1–2 concise sentences, focusing on the "
+            f"likely market impact and directional bias for {currency or 'affected instruments'}.\n\n"
+            f"Event: {event_name}\n"
+            f"Currency: {currency}\n"
+            f"Impact: {impact}\n"
+            f"Actual: {actual}\n"
+            f"Forecast: {forecast}\n"
+            f"Previous: {previous}\n"
+            f"Time: {event_time}\n\n"
+            f"Summary:"
+        )
+
+        message = self._client.messages.create(  # type: ignore[union-attr]
+            model=self._claude_model,
+            max_tokens=self._max_tokens,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return message.content[0].text.strip()
+
+    async def _reason_with_claude(self, setup: dict) -> str:
+        """Call Claude to generate structured trade reasoning."""
+        instrument = setup.get("instrument", "Unknown")
+        direction = setup.get("direction", "")
+        htf_bias = setup.get("htf_open_bias", "NEUTRAL")
+        htf_open = setup.get("htf_open", 0.0)
+        htf_high = setup.get("htf_high", 0.0)
+        htf_low = setup.get("htf_low", 0.0)
+        time_window = setup.get("time_window", "OFF_HOURS")
+        narrative_phase = setup.get("narrative_phase", "OFF")
+        price_vs_daily = setup.get("price_vs_daily_open", "")
+        price_vs_weekly = setup.get("price_vs_weekly_open", "")
+        price_vs_true_day = setup.get("price_vs_true_day_open", "")
+        patterns = setup.get("patterns", [])
+        confidence = setup.get("confidence_score", 0.0)
+        entry = setup.get("entry_price", 0.0)
+        sl = setup.get("sl_price", 0.0)
+        tp = setup.get("tp_price", 0.0)
+        swing_high = setup.get("swing_high")
+        swing_low = setup.get("swing_low")
+        fvg_present = setup.get("fvg_present", False)
+        sweep_time = setup.get("session_sweep_time", "")
+        sweep_level = setup.get("session_sweep_level", "")
+
+        window_label = _WINDOW_LABELS.get(time_window, time_window)
+        phase_desc = _PHASE_DESCRIPTIONS.get(narrative_phase, narrative_phase)
+
+        prompt = (
+            f"You are a professional ICT-trained trader. Generate structured trade "
+            f"reasoning for the following setup using the 3-question framework.\n\n"
+            f"Instrument: {instrument}\n"
+            f"Direction: {direction}\n"
+            f"HTF Open Bias: {htf_bias} (HTF open: {htf_open}, high: {htf_high}, low: {htf_low})\n"
+            f"Time Window: {window_label} — {phase_desc}\n"
+            f"Price vs Daily Open: {price_vs_daily}\n"
+            f"Price vs Weekly Open: {price_vs_weekly}\n"
+            f"Price vs True Day Open: {price_vs_true_day}\n"
+            f"Patterns detected: {', '.join(patterns) if patterns else 'None'}\n"
+            f"Confidence score: {confidence:.2f}\n"
+            f"Entry: {entry}, SL: {sl}, TP: {tp}\n"
+            f"Swing High: {swing_high}, Swing Low: {swing_low}\n"
+            f"FVG Present: {fvg_present}\n"
+            f"Session sweep: {sweep_level} at {sweep_time}\n\n"
+            f"Answer these 3 questions in 2–4 sentences total:\n"
+            f"1. Where has price come from? (HTF context, PD arrays swept/respected)\n"
+            f"2. Where is it now? (time window phase, price vs reference opens)\n"
+            f"3. Where is it likely to go? (nearest liquidity pool or imbalance)\n\n"
+            f"Entry bias rule: "
+            + (
+                "Bullish — note price is below session open (manipulation wick down expected before expansion up)."
+                if direction == "BULLISH"
+                else "Bearish — note price is above session open (manipulation wick up expected before expansion down)."
+                if direction == "BEARISH"
+                else "Neutral — describe the likely next move."
+            )
+            + "\n\nReasoning:"
+        )
+
+        message = self._client.messages.create(  # type: ignore[union-attr]
+            model=self._claude_model,
+            max_tokens=self._max_tokens,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return message.content[0].text.strip()
+
+    # ------------------------------------------------------------------
+    # Template fallbacks
+    # ------------------------------------------------------------------
+
+    def _summarise_template(self, event: dict) -> str:
+        """Template-based macro event summary (no LLM required)."""
+        event_name = event.get("event_name", "Unknown event")
+        currency = event.get("currency", "")
+        impact = event.get("impact", "")
+        actual = event.get("actual")
+        forecast = event.get("forecast")
+        previous = event.get("previous")
+
+        parts: list[str] = []
+
+        # Impact label
+        impact_label = f"{impact} impact" if impact else "Economic"
+        currency_label = f" ({currency})" if currency else ""
+        parts.append(f"{impact_label} event{currency_label}: {event_name}.")
+
+        # Actual vs forecast
+        if actual is not None and forecast is not None:
+            try:
+                actual_f = float(actual)
+                forecast_f = float(forecast)
+                if actual_f > forecast_f:
+                    bias = "beat expectations"
+                    direction_hint = "bullish" if currency not in ("USD",) else "hawkish"
+                elif actual_f < forecast_f:
+                    bias = "missed expectations"
+                    direction_hint = "bearish" if currency not in ("USD",) else "dovish"
+                else:
+                    bias = "met expectations"
+                    direction_hint = "neutral"
+                parts.append(
+                    f"Actual {actual} vs forecast {forecast} — {bias} ({direction_hint} bias)."
+                )
+            except (TypeError, ValueError):
+                parts.append(f"Actual: {actual}, Forecast: {forecast}.")
+        elif actual is not None:
+            parts.append(f"Actual: {actual}.")
+            if previous is not None:
+                parts.append(f"Previous: {previous}.")
+
+        return " ".join(parts)
+
+    def _reason_template(self, setup: dict) -> str:
+        """Template-based trade reasoning using get_narrative_context().
+
+        Implements the 3-question framework directly without an LLM.
+        """
+        # Import here to avoid circular imports at module level
+        from ml.features.session_features import get_narrative_context, TimeFeatures
+
+        instrument = setup.get("instrument", "Unknown")
+        direction = setup.get("direction", "")
+        htf_bias = setup.get("htf_open_bias", "NEUTRAL")
+        htf_open = setup.get("htf_open", 0.0)
+        htf_high = setup.get("htf_high", 0.0)
+        htf_low = setup.get("htf_low", 0.0)
+        time_window = setup.get("time_window", "OFF_HOURS")
+        narrative_phase = setup.get("narrative_phase", "OFF")
+        price_vs_daily = setup.get("price_vs_daily_open")
+        price_vs_weekly = setup.get("price_vs_weekly_open")
+        price_vs_true_day = setup.get("price_vs_true_day_open")
+        patterns = setup.get("patterns", [])
+        confidence = setup.get("confidence_score", 0.0)
+        entry = setup.get("entry_price", 0.0)
+        sl = setup.get("sl_price", 0.0)
+        tp = setup.get("tp_price", 0.0)
+        swing_high = setup.get("swing_high")
+        swing_low = setup.get("swing_low")
+        fvg_present = setup.get("fvg_present", False)
+        sweep_time = setup.get("session_sweep_time", "")
+        sweep_level = setup.get("session_sweep_level", "")
+
+        # Build TimeFeatures for get_narrative_context
+        time_window_weight = _TIME_WINDOW_WEIGHTS.get(time_window, 0.1)
+        is_killzone = time_window in {
+            "LONDON_KILLZONE", "LONDON_SILVER_BULLET",
+            "NY_AM_KILLZONE", "NY_AM_SILVER_BULLET",
+            "NY_PM_KILLZONE", "NY_PM_SILVER_BULLET",
+        }
+        time_features = TimeFeatures(
+            time_window=time_window,
+            narrative_phase=narrative_phase,
+            time_window_weight=time_window_weight,
+            is_killzone=is_killzone,
+            is_high_probability_window=time_window_weight >= 0.7,
+            price_vs_daily_open=price_vs_daily,
+            price_vs_weekly_open=price_vs_weekly,
+            price_vs_true_day_open=price_vs_true_day,
+        )
+
+        htf_features = {
+            "htf_open_bias": htf_bias,
+            "htf_open": htf_open,
+            "htf_high": htf_high,
+            "htf_low": htf_low,
+        }
+
+        zone_features = {
+            "swing_high": swing_high,
+            "swing_low": swing_low,
+            "fvg_present": fvg_present,
+        }
+
+        # Base narrative from get_narrative_context
+        base_narrative = get_narrative_context(time_features, htf_features, zone_features)
+
+        # Enrich with sweep context (Q1: where has price come from?)
+        parts: list[str] = []
+
+        if sweep_level and sweep_time:
+            parts.append(
+                f"Price swept the {sweep_level} at {sweep_time} "
+                f"({_WINDOW_LABELS.get(time_window, time_window)} — "
+                f"{_PHASE_DESCRIPTIONS.get(narrative_phase, narrative_phase)})."
+            )
+        else:
+            parts.append(base_narrative)
+
+        # HTF open bias (Q1 continuation)
+        if sweep_level and sweep_time:
+            parts.append(f"HTF open bias is {htf_bias}.")
+
+        # Price vs reference opens (Q2: where is it now?)
+        if price_vs_true_day:
+            fvg_note = " with a bullish FVG at discount" if (fvg_present and htf_bias == "BULLISH") else (
+                " with a bearish FVG at premium" if (fvg_present and htf_bias == "BEARISH") else ""
+            )
+            parts.append(
+                f"Price is {price_vs_true_day.lower()} the True Day Open{fvg_note}."
+            )
+
+        # Patterns
+        if patterns:
+            parts.append(f"Patterns: {', '.join(patterns)}.")
+
+        # Entry bias (Q2 continuation)
+        if direction == "BULLISH":
+            parts.append(
+                "Price is below session open — expecting manipulation wick down before expansion up."
+            )
+        elif direction == "BEARISH":
+            parts.append(
+                "Price is above session open — expecting manipulation wick up before expansion down."
+            )
+
+        # Q3: where is it likely to go?
+        if htf_bias == "BULLISH":
+            target = htf_high
+            target_label = "HTF high"
+            if swing_high:
+                target = swing_high
+                target_label = "swing high"
+            window_label = _WINDOW_LABELS.get("NY_AM_KILLZONE", "NY AM Killzone")
+            parts.append(
+                f"Expecting expansion higher into the {window_label} "
+                f"toward {target_label} at {target:.5f}."
+            )
+        elif htf_bias == "BEARISH":
+            target = htf_low
+            target_label = "HTF low"
+            if swing_low:
+                target = swing_low
+                target_label = "swing low"
+            window_label = _WINDOW_LABELS.get("NY_AM_KILLZONE", "NY AM Killzone")
+            parts.append(
+                f"Expecting expansion lower into the {window_label} "
+                f"toward {target_label} at {target:.5f}."
+            )
+
+        # Confidence and trade plan
+        if confidence > 0:
+            parts.append(f"Confidence: {confidence:.0%}.")
+        if entry and sl and tp:
+            r_ratio = abs(tp - entry) / abs(entry - sl) if abs(entry - sl) > 1e-9 else 0.0
+            parts.append(
+                f"Entry: {entry}, SL: {sl}, TP: {tp} ({r_ratio:.1f}R)."
+            )
+
+        return " ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Time window weights (mirrors session_features.py — kept local to avoid
+# circular imports at module level)
+# ---------------------------------------------------------------------------
+
+_TIME_WINDOW_WEIGHTS: dict[str, float] = {
+    "LONDON_SILVER_BULLET": 1.0,
+    "NY_AM_SILVER_BULLET": 1.0,
+    "NY_PM_SILVER_BULLET": 1.0,
+    "LONDON_KILLZONE": 0.9,
+    "NY_AM_KILLZONE": 0.9,
+    "NY_PM_KILLZONE": 0.9,
+    "NEWS_WINDOW": 0.8,
+    "TRUE_DAY_OPEN": 0.7,
+    "LONDON_CLOSE": 0.5,
+    "ASIAN_RANGE": 0.3,
+    "DAILY_CLOSE": 0.2,
+    "OFF_HOURS": 0.1,
+}

--- a/services/nlp/sentiment_pipeline.py
+++ b/services/nlp/sentiment_pipeline.py
@@ -1,0 +1,453 @@
+"""
+Sentiment pipeline for AgentICTrader.
+
+Fetches financial news from Alpha Vantage (or Reuters RSS fallback),
+classifies sentiment using FinBERT, caches results in Redis, and
+publishes signals to Kafka.
+
+Topics:
+  sentiment.signals — SentimentSignal messages (key=instrument)
+
+Redis keys:
+  sentiment:{instrument} — cached SentimentSignal (TTL 900s)
+"""
+from __future__ import annotations
+
+import json
+import logging
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from datetime import datetime, timezone, timedelta
+from typing import Optional
+
+import aiohttp
+import redis.asyncio as aioredis
+from aiokafka import AIOKafkaProducer
+
+try:
+    from transformers import pipeline
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "The 'transformers' package is required for the sentiment pipeline. "
+        "Install it with: pip install transformers>=4.39.0"
+    ) from exc
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SUPPORTED_INSTRUMENTS = [
+    "EURUSD", "GBPUSD", "US500", "US30", "XAUUSD", "BTCUSD", "ETHUSD", "XAUUSD"
+]
+
+# Instrument → currency/keyword mapping for news filtering
+INSTRUMENT_KEYWORDS: dict[str, list[str]] = {
+    "EURUSD": ["EUR", "euro", "ECB", "eurozone"],
+    "GBPUSD": ["GBP", "pound", "sterling", "BOE", "Bank of England"],
+    "US500":  ["S&P 500", "SPX", "US stocks", "equities", "Fed", "Federal Reserve"],
+    "US30":   ["Dow Jones", "DJIA", "US stocks", "equities", "Fed"],
+    "XAUUSD": ["gold", "XAU", "precious metals", "safe haven"],
+    "BTCUSD": ["bitcoin", "BTC", "crypto", "cryptocurrency"],
+    "ETHUSD": ["ethereum", "ETH", "crypto", "cryptocurrency"],
+}
+
+TOPIC_SENTIMENT = "sentiment.signals"
+FINBERT_MODEL = "ProsusAI/finbert"
+TTL_SENTIMENT = 900  # 15 minutes
+
+# Alpha Vantage news endpoint
+_AV_URL = (
+    "https://www.alphavantage.co/query"
+    "?function=NEWS_SENTIMENT&tickers={ticker}&apikey={key}&limit=50"
+)
+# Reuters RSS fallback
+_REUTERS_RSS_URL = "https://feeds.reuters.com/reuters/businessNews"
+
+# Time format used by Alpha Vantage: "20240115T103000"
+_AV_TIME_FORMAT = "%Y%m%dT%H%M%S"
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SentimentSignal:
+    """Sentiment signal for a single instrument."""
+    instrument: str
+    score: float          # -1.0 (bearish) to +1.0 (bullish)
+    direction: str        # "BULLISH" | "BEARISH" | "NEUTRAL"
+    freshness_seconds: int
+    source: str           # "alpha_vantage" | "reuters_rss" | "mock"
+
+
+@dataclass
+class NewsArticle:
+    """A single news article."""
+    title: str
+    summary: str
+    published_at: datetime
+    source: str
+    url: str = ""
+
+
+# ---------------------------------------------------------------------------
+# SentimentPipeline
+# ---------------------------------------------------------------------------
+
+class SentimentPipeline:
+    """
+    End-to-end sentiment pipeline: fetch news → classify → cache → publish.
+
+    Usage::
+
+        pipeline = SentimentPipeline(alpha_vantage_api_key="YOUR_KEY")
+        await pipeline.connect()
+        signal = await pipeline.run_once("EURUSD")
+        await pipeline.close()
+    """
+
+    def __init__(
+        self,
+        kafka_bootstrap_servers: str = "localhost:9092",
+        redis_host: str = "localhost",
+        redis_port: int = 6379,
+        alpha_vantage_api_key: str = "",
+        finbert_model: str = FINBERT_MODEL,
+    ) -> None:
+        self._kafka_bootstrap_servers = kafka_bootstrap_servers
+        self._redis_host = redis_host
+        self._redis_port = redis_port
+        self._alpha_vantage_api_key = alpha_vantage_api_key
+        self._finbert_model = finbert_model
+
+        self._producer: Optional[AIOKafkaProducer] = None
+        self._redis: Optional[aioredis.Redis] = None
+        # FinBERT classifier — loaded lazily on first call to classify_sentiment
+        self._classifier = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> None:
+        """Start Kafka producer and Redis connection."""
+        self._producer = AIOKafkaProducer(
+            bootstrap_servers=self._kafka_bootstrap_servers,
+        )
+        await self._producer.start()
+
+        self._redis = aioredis.Redis(
+            host=self._redis_host,
+            port=self._redis_port,
+            decode_responses=True,
+        )
+        logger.info(
+            "SentimentPipeline connected (kafka=%s, redis=%s:%s)",
+            self._kafka_bootstrap_servers,
+            self._redis_host,
+            self._redis_port,
+        )
+
+    async def close(self) -> None:
+        """Flush Kafka, close Redis."""
+        if self._producer is not None:
+            try:
+                await self._producer.flush()
+                await self._producer.stop()
+            except Exception:
+                pass
+            finally:
+                self._producer = None
+
+        if self._redis is not None:
+            try:
+                await self._redis.aclose()
+            except Exception:
+                pass
+            finally:
+                self._redis = None
+
+        logger.info("SentimentPipeline closed")
+
+    # ------------------------------------------------------------------
+    # News fetching
+    # ------------------------------------------------------------------
+
+    async def fetch_news(self, instrument: str) -> list[NewsArticle]:
+        """Fetch news articles for *instrument* from Alpha Vantage.
+
+        Falls back to Reuters RSS if ``alpha_vantage_api_key`` is empty.
+        Returns an empty list on HTTP error (never raises).
+        """
+        if self._alpha_vantage_api_key:
+            return await self._fetch_alpha_vantage(instrument)
+        return await self._fetch_reuters_rss(instrument)
+
+    async def _fetch_alpha_vantage(self, instrument: str) -> list[NewsArticle]:
+        """Fetch from Alpha Vantage NEWS_SENTIMENT endpoint."""
+        # Map instrument to a ticker symbol Alpha Vantage understands
+        ticker = instrument  # e.g. "EURUSD", "XAUUSD" — AV accepts forex tickers
+        url = _AV_URL.format(ticker=ticker, key=self._alpha_vantage_api_key)
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(hours=24)
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(url) as resp:
+                    if resp.status != 200:
+                        logger.warning(
+                            "Alpha Vantage returned HTTP %s for %s", resp.status, instrument
+                        )
+                        return []
+                    data = await resp.json()
+        except Exception as exc:
+            logger.warning("Alpha Vantage fetch failed for %s: %s", instrument, exc)
+            return []
+
+        articles: list[NewsArticle] = []
+        for item in data.get("feed", []):
+            try:
+                published_at = datetime.strptime(
+                    item["time_published"], _AV_TIME_FORMAT
+                ).replace(tzinfo=timezone.utc)
+            except (KeyError, ValueError):
+                continue
+
+            if published_at < cutoff:
+                continue  # older than 24 hours — skip
+
+            articles.append(
+                NewsArticle(
+                    title=item.get("title", ""),
+                    summary=item.get("summary", ""),
+                    published_at=published_at,
+                    source=item.get("source", "alpha_vantage"),
+                    url=item.get("url", ""),
+                )
+            )
+
+        logger.debug("Alpha Vantage returned %d articles for %s", len(articles), instrument)
+        return articles
+
+    async def _fetch_reuters_rss(self, instrument: str) -> list[NewsArticle]:
+        """Fetch from Reuters RSS and filter by instrument keywords."""
+        keywords = INSTRUMENT_KEYWORDS.get(instrument, [])
+        cutoff = datetime.now(tz=timezone.utc) - timedelta(hours=24)
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(_REUTERS_RSS_URL) as resp:
+                    if resp.status != 200:
+                        logger.warning(
+                            "Reuters RSS returned HTTP %s for %s", resp.status, instrument
+                        )
+                        return []
+                    text = await resp.text()
+        except Exception as exc:
+            logger.warning("Reuters RSS fetch failed for %s: %s", instrument, exc)
+            return []
+
+        articles: list[NewsArticle] = []
+        try:
+            root = ET.fromstring(text)
+        except ET.ParseError as exc:
+            logger.warning("Reuters RSS parse error: %s", exc)
+            return []
+
+        for item in root.iter("item"):
+            title = (item.findtext("title") or "").strip()
+            description = (item.findtext("description") or "").strip()
+            pub_date_str = (item.findtext("pubDate") or "").strip()
+            link = (item.findtext("link") or "").strip()
+
+            # Filter by instrument keywords
+            combined = f"{title} {description}"
+            if keywords and not any(kw.lower() in combined.lower() for kw in keywords):
+                continue
+
+            # Parse pubDate (RFC 2822 format)
+            published_at: datetime
+            try:
+                from email.utils import parsedate_to_datetime
+                published_at = parsedate_to_datetime(pub_date_str)
+                if published_at.tzinfo is None:
+                    published_at = published_at.replace(tzinfo=timezone.utc)
+            except Exception:
+                published_at = datetime.now(tz=timezone.utc)
+
+            if published_at < cutoff:
+                continue
+
+            articles.append(
+                NewsArticle(
+                    title=title,
+                    summary=description,
+                    published_at=published_at,
+                    source="reuters_rss",
+                    url=link,
+                )
+            )
+
+        logger.debug("Reuters RSS returned %d articles for %s", len(articles), instrument)
+        return articles
+
+    # ------------------------------------------------------------------
+    # Sentiment classification
+    # ------------------------------------------------------------------
+
+    def classify_sentiment(self, articles: list[NewsArticle]) -> float:
+        """Run FinBERT on each article's title + summary.
+
+        Returns mean score in [-1.0, +1.0]:
+          - FinBERT 'positive' label → +score
+          - FinBERT 'negative' label → -score
+          - FinBERT 'neutral'  label → 0.0
+
+        Returns 0.0 if *articles* is empty.
+        """
+        if not articles:
+            return 0.0
+
+        # Lazy-load FinBERT on first call
+        if self._classifier is None:
+            self._classifier = pipeline(
+                "text-classification",
+                model=self._finbert_model,
+            )
+
+        scores: list[float] = []
+        for article in articles:
+            text = f"{article.title}. {article.summary}"[:512]
+            try:
+                result = self._classifier(text)
+                label = result[0]["label"].lower()
+                confidence = float(result[0]["score"])
+                if label == "positive":
+                    scores.append(confidence)
+                elif label == "negative":
+                    scores.append(-confidence)
+                else:  # neutral
+                    scores.append(0.0)
+            except Exception as exc:
+                logger.warning("FinBERT classification failed: %s", exc)
+                scores.append(0.0)
+
+        if not scores:
+            return 0.0
+
+        mean_score = sum(scores) / len(scores)
+        # Clamp to [-1.0, +1.0]
+        return max(-1.0, min(1.0, mean_score))
+
+    # ------------------------------------------------------------------
+    # Direction mapping
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def score_to_direction(score: float) -> str:
+        """Map a numeric score to a direction string.
+
+        score > 0.1  → 'BULLISH'
+        score < -0.1 → 'BEARISH'
+        else         → 'NEUTRAL'
+        """
+        if score > 0.1:
+            return "BULLISH"
+        if score < -0.1:
+            return "BEARISH"
+        return "NEUTRAL"
+
+    # ------------------------------------------------------------------
+    # Signal computation
+    # ------------------------------------------------------------------
+
+    async def compute_signal(self, instrument: str) -> SentimentSignal:
+        """Fetch news, classify, return a SentimentSignal."""
+        articles = await self.fetch_news(instrument)
+        score = self.classify_sentiment(articles)
+        direction = self.score_to_direction(score)
+
+        # freshness_seconds = seconds since the most recent article's published_at
+        if articles:
+            most_recent = max(a.published_at for a in articles)
+            now = datetime.now(tz=timezone.utc)
+            freshness_seconds = max(0, int((now - most_recent).total_seconds()))
+            source = articles[0].source
+        else:
+            freshness_seconds = 0
+            source = "alpha_vantage" if self._alpha_vantage_api_key else "reuters_rss"
+
+        return SentimentSignal(
+            instrument=instrument,
+            score=score,
+            direction=direction,
+            freshness_seconds=freshness_seconds,
+            source=source,
+        )
+
+    # ------------------------------------------------------------------
+    # Publishing
+    # ------------------------------------------------------------------
+
+    async def publish_signal(self, signal: SentimentSignal) -> None:
+        """Publish *signal* to Kafka topic ``sentiment.signals``.
+
+        Message key  = instrument (bytes).
+        Message value = JSON: {instrument, score, direction, freshness_seconds, source}
+        """
+        key = signal.instrument.encode("utf-8")
+        value = json.dumps(
+            {
+                "instrument": signal.instrument,
+                "score": signal.score,
+                "direction": signal.direction,
+                "freshness_seconds": signal.freshness_seconds,
+                "source": signal.source,
+            }
+        ).encode("utf-8")
+        await self._producer.send(TOPIC_SENTIMENT, key=key, value=value)
+        logger.debug("Published sentiment signal for %s to %s", signal.instrument, TOPIC_SENTIMENT)
+
+    # ------------------------------------------------------------------
+    # Caching
+    # ------------------------------------------------------------------
+
+    async def cache_signal(self, signal: SentimentSignal) -> None:
+        """Cache *signal* in Redis.
+
+        Key  = ``sentiment:{instrument}``
+        TTL  = 900 seconds
+        Value = JSON dict: {score, direction, freshness_seconds, source}
+        """
+        key = f"sentiment:{signal.instrument}"
+        value = json.dumps(
+            {
+                "score": signal.score,
+                "direction": signal.direction,
+                "freshness_seconds": signal.freshness_seconds,
+                "source": signal.source,
+            }
+        )
+        await self._redis.set(key, value, ex=TTL_SENTIMENT)
+        logger.debug("Cached sentiment signal for %s (TTL=%ss)", signal.instrument, TTL_SENTIMENT)
+
+    # ------------------------------------------------------------------
+    # Orchestration
+    # ------------------------------------------------------------------
+
+    async def run_once(self, instrument: str) -> SentimentSignal:
+        """compute_signal → cache_signal → publish_signal → return signal."""
+        signal = await self.compute_signal(instrument)
+        await self.cache_signal(signal)
+        await self.publish_signal(signal)
+        return signal
+
+    async def run_all(self) -> list[SentimentSignal]:
+        """run_once for all SUPPORTED_INSTRUMENTS, return list of signals."""
+        signals: list[SentimentSignal] = []
+        for instrument in SUPPORTED_INSTRUMENTS:
+            signal = await self.run_once(instrument)
+            signals.append(signal)
+        return signals


### PR DESCRIPTION
 LLM Macro Event Summariser & Trade Reasoning Generator

**Branch:** `feature/task-27-llm-service`  
**Spec:** Phase 2 — Intelligence Layer, Task 27  
**Tests:** 53 / 53 passing  

---

## What was built

### `services/nlp/llm_service.py` — `LLMService`

A dual-mode LLM service that uses **Claude (Anthropic)** as the primary engine with automatic **template-based fallback** when the API is unavailable or the key is absent.

---

### `summarise_macro_event(event: dict) → str`

- Sends a trader-focused prompt to Claude asking for a 1–2 sentence market impact summary
- Template fallback compares `actual` vs `forecast` to derive a directional bias label: *beat / missed / met expectations*
- Handles missing fields gracefully — never raises, never returns an empty string

---

### `generate_trade_reasoning(setup: dict) → str`

Generates structured trade reasoning built around the **3-question ICT narrative framework**:

1. **Where has price come from?** — HTF context, session range swept, PD arrays respected
2. **Where is it now?** — current time window phase (e.g. London Killzone = manipulation), price vs Daily / Weekly / True Day Open
3. **Where is it likely to go?** — nearest liquidity pool (swing high/low) or imbalance (FVG/IFVG) to rebalance

Entry bias rules encoded in both the Claude prompt and the template fallback:

- **Bullish** → price is below session open (manipulation wick down expected before expansion up)
- **Bearish** → price is above session open (manipulation wick up expected before expansion down)

Template fallback delegates to `get_narrative_context()` from `ml/features/session_features.py` and enriches it with session sweep context, FVG notes, confidence score, and R-ratio.

**Example output (matches spec):**

```
Price swept the Asian range low at 03:15 NY (London Killzone — manipulation phase).
HTF open bias is bullish. Price is below the True Day Open with a bullish FVG at discount.
Expecting expansion higher into the NY AM Killzone (07:00–10:00 NY) toward HTF high at 1.09200.
Confidence: 82%. Entry: 1.0865, SL: 1.084, TP: 1.0915 (2.0R).
```

---

## Files changed

| File | Change |
|------|--------|
| `services/nlp/llm_service.py` | New — `LLMService` class |
| `backend/tests/test_llm_service.py` | New — 53 unit tests |
| `services/nlp/__init__.py` | Updated — exports `LLMService`, `CLAUDE_MODEL` |
| `services/nlp/sentiment_pipeline.py` | New — FinBERT sentiment pipeline |
| `services/nlp/calendar_monitor.py` | New — economic calendar blackout monitor |
| `backend/tests/test_sentiment_pipeline.py` | New — sentiment pipeline tests |
| `backend/tests/test_calendar_monitor.py` | New — calendar monitor tests |
| `.kiro/specs/agentictrader-platform/tasks.md` | Task 27 marked complete |

---

## Test coverage

| Group | Tests |
|-------|-------|
| `LLMService` init (with/without API key, model, max_tokens) | 5 |
| `summarise_macro_event` — Claude path (model, prompt contents, currency, stripping) | 6 |
| `summarise_macro_event` — template fallback (beat/missed/met, missing fields, impact) | 9 |
| `generate_trade_reasoning` — Claude path (model, instrument, direction, HTF bias, time window, 3-question framework, manipulation wick notes) | 10 |
| `generate_trade_reasoning` — template fallback (HTF bias, time window, phase, sweep, FVG, targets, confidence, entry/SL/TP, entry bias notes) | 16 |
| Spec example output validation | 2 |
| Constants (`CLAUDE_MODEL`, `_PHASE_DESCRIPTIONS`, `_WINDOW_LABELS`) | 4 |
| **Total** | **53** |

---

## Design notes

- `anthropic` is imported with a `try/except` guard — the service degrades cleanly if the SDK is not installed
- `_ANTHROPIC_AVAILABLE` flag controls the init path, making it straightforward to mock in tests
- Time window weights are kept local to `llm_service.py` (mirroring `session_features.py`) to avoid circular imports at module level
- `get_narrative_context()` is imported lazily inside `_reason_template()` for the same reason
- All Claude calls are synchronous (`client.messages.create`) wrapped in `async` methods — compatible with the existing async service pattern used across the codebase
