### PR TITLE
feat(rag): implement setup ingestion service (tasks 6-7)

### DIFF
--- a/.kiro/specs/rag-enhancement/tasks.md
+++ b/.kiro/specs/rag-enhancement/tasks.md
@@ -137,33 +137,33 @@ This implementation plan breaks down the **AlgoRAG** feature into discrete, test
 
 ### Phase 3: Vector Store Integration
 
-- [ ] 6. Implement Qdrant collection management
-  - [ ] 6.1 Create vector store schema and collection
+- [x] 6. Implement Qdrant collection management
+  - [x] 6.1 Create vector store schema and collection
     - **RED**: Test collection creation with 528-dim vectors, cosine distance
     - **GREEN**: Implement collection creation with payload schema (trade_id, timestamp, instrument, etc.)
     - **REFACTOR**: Add idempotent collection creation (skip if exists)
     - _Requirements: FR-RAG-1_
   
-  - [ ] 6.2 Implement metadata indexing
+  - [x] 6.2 Implement metadata indexing
     - **RED**: Test creation of indexes on instrument, time_window, htf_open_bias, outcome_result
     - **GREEN**: Implement index creation for fast metadata filtering
     - **REFACTOR**: Add index validation and rebuild capability
     - _Requirements: FR-RAG-2_
   
-  - [ ]* 6.3 Write tests for collection management
+  - [x] 6.3 Write tests for collection management
     - Test collection creation, deletion, recreation
     - Test index creation and query performance
     - Test schema validation
     - _Requirements: FR-RAG-1, NFR-RAG-2_
 
-- [ ] 7. Implement setup ingestion to vector store
-  - [ ] 7.1 Create ingestion service
+- [x] 7. Implement setup ingestion to vector store
+  - [x] 7.1 Create ingestion service
     - **RED**: Test batch ingestion of enriched setups with embeddings to Qdrant
     - **GREEN**: Implement batch upsert with error handling and retry logic
     - **REFACTOR**: Add progress tracking and logging
     - _Requirements: FR-RAG-1, FR-RAG-7_
   
-  - [ ] 7.2 Implement duplicate detection
+  - [x] 7.2 Implement duplicate detection
     - **RED**: Test detection and handling of duplicate trade_ids
     - **GREEN**: Implement upsert logic (update if exists, insert if new)
     - **REFACTOR**: Add conflict resolution strategy

--- a/services/algorag/ingestion_service.py
+++ b/services/algorag/ingestion_service.py
@@ -1,0 +1,333 @@
+"""
+AlgoRAG Ingestion Service.
+
+Provides IngestionService — a high-level service for batch-ingesting enriched
+trading setups with pre-computed 528-dim embeddings into the Qdrant vector store.
+
+Key responsibilities:
+  - Validates embedding dimensions before any network call
+  - Builds deterministic PointStruct IDs from trade_id (uuid5) so Qdrant
+    upsert semantics guarantee deduplication server-side
+  - Supports configurable batch sizes for efficient bulk ingestion
+  - Tracks seen trade_ids in-session for optional SKIP duplicate strategy
+  - Captures per-batch failures with full error context for progress reporting
+
+Usage example::
+
+    from services.algorag.ingestion_service import IngestionService, DuplicateStrategy
+    from services.algorag.qdrant_client import QdrantClientWrapper
+
+    wrapper = QdrantClientWrapper()
+    await wrapper.ensure_collection()
+
+    svc = IngestionService(wrapper=wrapper)
+    result = await svc.ingest_batch(list_of_setup_embedding_pairs)
+    print(f"Ingested {result.successful}/{result.total} setups")
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from qdrant_client.http import models as qmodels
+
+from services.algorag.config import QdrantConfig, settings
+from services.algorag.qdrant_client import QdrantClientWrapper, QdrantConnectionError
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+EMBEDDING_DIM: int = 528
+"""Expected dimensionality of the combined multi-modal embedding vector."""
+
+DEFAULT_BATCH_SIZE: int = 100
+"""Default number of setups submitted in a single Qdrant upsert call."""
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+class DuplicateStrategy(str, Enum):
+    """Strategy for handling duplicate trade_ids during ingestion.
+
+    UPSERT — always forward to Qdrant; Qdrant's upsert semantics overwrite the
+             existing point if the ID already exists.  This is the default.
+    SKIP   — check the in-session seen_trade_ids set and skip any trade_id that
+             has already been ingested in this service session.
+    """
+    UPSERT = "upsert"
+    SKIP = "skip"
+
+
+@dataclass
+class BatchIngestionResult:
+    """Summary of a completed ingest_batch() call.
+
+    Attributes:
+        total:        Total number of setups submitted (including skipped/failed).
+        successful:   Number of setups successfully upserted to Qdrant.
+        failed:       Number of setups that could not be upserted due to errors.
+        skipped:      Number of setups skipped due to the SKIP duplicate strategy.
+        ingested_ids: Qdrant point UUIDs for successfully ingested setups.
+        errors:       List of (trade_id, error_message) tuples for failed setups.
+    """
+    total: int = 0
+    successful: int = 0
+    failed: int = 0
+    skipped: int = 0
+    ingested_ids: List[str] = field(default_factory=list)
+    errors: List[Tuple[str, str]] = field(default_factory=list)
+
+
+class IngestionServiceError(RuntimeError):
+    """Raised when a batch ingestion cannot be completed at all.
+
+    Distinguishable from per-item failures (which are recorded in
+    BatchIngestionResult.errors) so that callers can choose a different
+    error-handling path for catastrophic vs. partial failures.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Pure helper
+# ---------------------------------------------------------------------------
+
+
+def build_point_from_setup(
+    setup: Dict[str, Any],
+    embedding: List[float],
+) -> qmodels.PointStruct:
+    """Build a Qdrant PointStruct from an enriched setup and its embedding.
+
+    The PointStruct ID is derived deterministically from the setup's trade_id
+    using uuid5(NAMESPACE_DNS, trade_id).  This ensures that re-ingesting the
+    same trade_id always produces the same point ID, so Qdrant's upsert
+    semantics overwrite rather than duplicate the existing record.
+
+    Args:
+        setup:     Enriched setup dict (must include at least "trade_id" key,
+                   or a UUID will be generated).
+        embedding: Pre-computed 528-dim embedding vector.
+
+    Returns:
+        A fully-populated qmodels.PointStruct ready for upsert.
+
+    Raises:
+        ValueError: If the embedding does not have exactly EMBEDDING_DIM (528)
+                    dimensions.
+    """
+    if len(embedding) != EMBEDDING_DIM:
+        raise ValueError(
+            f"Embedding must be {EMBEDDING_DIM}-dimensional, got {len(embedding)}"
+        )
+
+    trade_id: str = setup.get("trade_id") or str(uuid.uuid4())
+    point_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, trade_id))
+
+    payload: Dict[str, Any] = {
+        "trade_id": trade_id,
+        "timestamp": setup.get("timestamp"),
+        "instrument": str(setup.get("instrument", "")).upper(),
+        "time_window": setup.get("time_window", ""),
+        "htf_open_bias": setup.get("htf_open_bias", ""),
+        "confluence_count": setup.get("confluence_count", 0),
+        "outcome_result": setup.get("outcome_result", ""),
+        "outcome_r_multiple": setup.get("outcome_r_multiple", 0.0),
+        "narrative": setup.get("narrative", ""),
+        "full_setup": setup,
+    }
+
+    return qmodels.PointStruct(
+        id=point_id,
+        vector=embedding,
+        payload=payload,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ingestion service
+# ---------------------------------------------------------------------------
+
+
+class IngestionService:
+    """Batch-ingestion service for enriched trading setups.
+
+    Accepts a list of (enriched_setup, embedding) pairs, validates embeddings,
+    builds PointStructs, and upserts them to Qdrant in configurable batches.
+
+    Supports an optional SKIP duplicate strategy that tracks seen trade_ids
+    in-session to avoid redundant network calls for already-ingested setups.
+
+    Attributes:
+        duplicate_strategy: Controls how duplicate trade_ids are handled.
+        seen_trade_ids:      Set of trade_ids ingested in the current session.
+    """
+
+    def __init__(
+        self,
+        *,
+        wrapper: Optional[QdrantClientWrapper] = None,
+        config: Optional[QdrantConfig] = None,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+        duplicate_strategy: DuplicateStrategy = DuplicateStrategy.UPSERT,
+    ) -> None:
+        self._wrapper: QdrantClientWrapper = wrapper or QdrantClientWrapper(
+            config=config or settings.qdrant
+        )
+        self._config: QdrantConfig = config or settings.qdrant
+        self._batch_size: int = batch_size
+        self.duplicate_strategy: DuplicateStrategy = duplicate_strategy
+        self.seen_trade_ids: Set[str] = set()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def ingest_batch(
+        self,
+        items: List[Tuple[Dict[str, Any], List[float]]],
+    ) -> BatchIngestionResult:
+        """Ingest a batch of (enriched_setup, embedding) pairs into Qdrant.
+
+        Validates embedding dimensions, applies the duplicate strategy, builds
+        PointStructs, and submits them to Qdrant in sub-batches of batch_size.
+
+        Args:
+            items: List of (setup_dict, embedding) pairs to ingest.
+
+        Returns:
+            BatchIngestionResult with counts and ingested point IDs.
+
+        Raises:
+            ValueError:             If any embedding has the wrong dimension
+                                    (validation is eager — raised before any
+                                    network call is made).
+            IngestionServiceError:  If the entire batch fails with a single
+                                    sub-batch and no partial progress is
+                                    possible.
+        """
+        result = BatchIngestionResult(total=len(items))
+
+        if not items:
+            return result
+
+        # --- Validate all embedding dimensions eagerly ---
+        for setup, embedding in items:
+            if len(embedding) != EMBEDDING_DIM:
+                raise ValueError(
+                    f"Embedding must be {EMBEDDING_DIM}-dimensional, got {len(embedding)}"
+                )
+
+        # --- Apply duplicate strategy ---
+        filtered = self._apply_duplicate_strategy(items, result)
+
+        if not filtered:
+            return result
+
+        # --- Build PointStructs ---
+        points: List[qmodels.PointStruct] = [
+            build_point_from_setup(setup, embedding)
+            for setup, embedding in filtered
+        ]
+
+        # --- Batch-upsert with per-batch error handling ---
+        if self._batch_size >= len(points):
+            # Single upsert covers everything — raise on failure so the caller
+            # knows the batch was not partially committed
+            try:
+                await self._wrapper.upsert(
+                    points=points,
+                    collection_name=self._config.collection,
+                )
+            except QdrantConnectionError as exc:
+                raise IngestionServiceError(
+                    f"Batch ingestion failed: {exc}"
+                ) from exc
+            except Exception as exc:
+                raise IngestionServiceError(
+                    f"Batch ingestion failed: {exc}"
+                ) from exc
+
+            result.successful = len(points)
+            result.ingested_ids = [str(p.id) for p in points]
+            # Track seen trade_ids
+            for p in points:
+                self.seen_trade_ids.add(p.payload["trade_id"])
+        else:
+            # Multiple batches — track partial failures individually
+            await self._upsert_in_batches(points, filtered, result)
+
+        logger.info(
+            "Ingestion complete: %d/%d successful, %d failed, %d skipped",
+            result.successful,
+            result.total,
+            result.failed,
+            result.skipped,
+        )
+        return result
+
+    def clear_seen_ids(self) -> None:
+        """Reset the in-session duplicate detection cache."""
+        self.seen_trade_ids.clear()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _apply_duplicate_strategy(
+        self,
+        items: List[Tuple[Dict[str, Any], List[float]]],
+        result: BatchIngestionResult,
+    ) -> List[Tuple[Dict[str, Any], List[float]]]:
+        """Filter items according to duplicate_strategy; update result.skipped."""
+        if self.duplicate_strategy == DuplicateStrategy.UPSERT:
+            return list(items)
+
+        # SKIP strategy: filter out already-seen trade_ids
+        filtered: List[Tuple[Dict[str, Any], List[float]]] = []
+        for setup, embedding in items:
+            trade_id = setup.get("trade_id") or ""
+            if trade_id in self.seen_trade_ids:
+                result.skipped += 1
+                logger.debug("Skipping duplicate trade_id: %s", trade_id)
+            else:
+                filtered.append((setup, embedding))
+        return filtered
+
+    async def _upsert_in_batches(
+        self,
+        points: List[qmodels.PointStruct],
+        filtered: List[Tuple[Dict[str, Any], List[float]]],
+        result: BatchIngestionResult,
+    ) -> None:
+        """Submit points to Qdrant in sub-batches; capture per-batch failures."""
+        for batch_start in range(0, len(points), self._batch_size):
+            batch = points[batch_start : batch_start + self._batch_size]
+            try:
+                await self._wrapper.upsert(
+                    points=batch,
+                    collection_name=self._config.collection,
+                )
+                result.successful += len(batch)
+                result.ingested_ids.extend(str(p.id) for p in batch)
+                for p in batch:
+                    self.seen_trade_ids.add(p.payload["trade_id"])
+            except Exception as exc:
+                result.failed += len(batch)
+                for p in batch:
+                    result.errors.append((p.payload.get("trade_id", ""), str(exc)))
+                logger.warning(
+                    "Batch upsert failed for %d points (offset %d): %s",
+                    len(batch),
+                    batch_start,
+                    exc,
+                )

--- a/services/algorag/qdrant_client.py
+++ b/services/algorag/qdrant_client.py
@@ -1,11 +1,24 @@
 """
 Qdrant client wrapper with connection pooling, collection management,
 and retry logic. All configuration is read from services.algorag.config.
+
+Usage example::
+
+    from services.algorag.qdrant_client import QdrantClientWrapper
+
+    wrapper = QdrantClientWrapper()
+    await wrapper.ensure_collection()         # idempotent — skips if exists
+    is_valid = await wrapper.validate_indexes()
+    if not is_valid:
+        await wrapper.rebuild_indexes()
+    await wrapper.upsert([point])
+    results = await wrapper.search(query_vector=[...], limit=10)
+    await wrapper.close()
 """
 
 import asyncio
 import logging
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 from qdrant_client import AsyncQdrantClient
 from qdrant_client.http import models as qmodels
@@ -15,7 +28,24 @@ from services.algorag.config import QdrantConfig, settings
 
 logger = logging.getLogger(__name__)
 
-VECTOR_DIM = 528
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+VECTOR_DIM: int = 528
+"""Dimensionality of the combined multi-modal embedding vector (design spec)."""
+
+INDEXED_FIELDS: Tuple[str, ...] = (
+    "instrument",
+    "time_window",
+    "htf_open_bias",
+    "outcome_result",
+)
+"""Payload fields that receive a KEYWORD index for fast metadata filtering.
+
+These match the filterable attributes used in the retrieval pipeline
+(FR-RAG-2) and the Qdrant collection schema in the design doc.
+"""
 
 
 class QdrantConnectionError(Exception):
@@ -74,7 +104,10 @@ class QdrantClientWrapper:
     ) -> None:
         """
         Create the collection if it does not yet exist (idempotent).
-        Uses cosine distance and creates payload indexes for fast filtering.
+
+        Uses cosine distance and 528-dim vectors per the design spec.
+        After creation, calls ensure_indexes() to build all payload indexes
+        required for fast metadata filtering (FR-RAG-2).
         """
         name = collection_name or self._config.collection
         client = self.get_client()
@@ -90,13 +123,103 @@ class QdrantClientWrapper:
                     distance=qmodels.Distance.COSINE,
                 ),
             )
-            # Create payload indexes for common metadata filters
-            for field in ("instrument", "time_window", "htf_open_bias", "outcome_result"):
-                await client.create_payload_index(
-                    collection_name=name,
-                    field_name=field,
-                    field_schema=qmodels.PayloadSchemaType.KEYWORD,
+            await self.ensure_indexes(collection_name=name)
+
+    async def ensure_indexes(
+        self,
+        collection_name: Optional[str] = None,
+    ) -> None:
+        """
+        Create KEYWORD payload indexes on all INDEXED_FIELDS (idempotent).
+
+        Qdrant silently accepts duplicate index creation requests, so this
+        method is safe to call on an existing collection without side-effects.
+        Used both during initial setup (via ensure_collection) and for manual
+        rebuild via rebuild_indexes().
+
+        Fields indexed: instrument, time_window, htf_open_bias, outcome_result
+        These enable exact-match metadata pre-filtering in the retrieval
+        pipeline, improving both precision and query latency (FR-RAG-2).
+        """
+        name = collection_name or self._config.collection
+        client = self.get_client()
+        for field in INDEXED_FIELDS:
+            await client.create_payload_index(
+                collection_name=name,
+                field_name=field,
+                field_schema=qmodels.PayloadSchemaType.KEYWORD,
+            )
+        logger.info(
+            "Payload indexes ensured for collection '%s': %s",
+            name,
+            list(INDEXED_FIELDS),
+        )
+
+    async def validate_indexes(
+        self,
+        collection_name: Optional[str] = None,
+    ) -> bool:
+        """
+        Return True if all INDEXED_FIELDS have an active payload index.
+
+        Retrieves the collection's payload_schema from Qdrant and checks that
+        every field in INDEXED_FIELDS is present. Returns False — not raises —
+        on any error, so callers can treat this as a simple health check.
+
+        Typical usage::
+
+            if not await wrapper.validate_indexes():
+                await wrapper.rebuild_indexes()
+        """
+        name = collection_name or self._config.collection
+        try:
+            info = await self.get_client().get_collection(name)
+            indexed = set(info.payload_schema or {})
+            missing = set(INDEXED_FIELDS) - indexed
+            if missing:
+                logger.warning(
+                    "Collection '%s' is missing payload indexes: %s", name, missing
                 )
+                return False
+            return True
+        except Exception as exc:
+            logger.error(
+                "Could not validate indexes for collection '%s': %s", name, exc
+            )
+            return False
+
+    async def rebuild_indexes(
+        self,
+        collection_name: Optional[str] = None,
+    ) -> None:
+        """
+        Force-recreate all payload indexes on the collection.
+
+        Safe to call on a healthy collection — Qdrant treats duplicate index
+        creation as a no-op.  Use this after a schema migration or when
+        validate_indexes() returns False.
+
+        Operational runbook step: ``await wrapper.rebuild_indexes()``
+        """
+        name = collection_name or self._config.collection
+        logger.info("Rebuilding payload indexes on collection '%s'", name)
+        await self.ensure_indexes(collection_name=name)
+        logger.info("Payload index rebuild complete for collection '%s'", name)
+
+    async def delete_collection(
+        self,
+        collection_name: Optional[str] = None,
+    ) -> None:
+        """
+        Delete the collection from Qdrant.
+
+        Intended for test teardown and data-refresh runbooks only.
+        After deletion the collection must be recreated via ensure_collection()
+        before any reads or writes.
+        """
+        name = collection_name or self._config.collection
+        logger.warning("Deleting collection '%s' — this is irreversible", name)
+        await self.get_client().delete_collection(collection_name=name)
 
     # ------------------------------------------------------------------
     # CRUD helpers

--- a/services/algorag/tests/test_collection_management.py
+++ b/services/algorag/tests/test_collection_management.py
@@ -1,0 +1,954 @@
+"""
+TDD – Task 6: Qdrant collection management (schema, creation, indexing).
+
+RED  phase: tests for collection schema validation, idempotent creation,
+            metadata index creation, index validation, and rebuild capability.
+GREEN phase: implementation lives in QdrantClientWrapper.ensure_collection()
+             and the new QdrantClientWrapper.ensure_indexes() method.
+REFACTOR: index validation and rebuild separated into validate_indexes() /
+          rebuild_indexes() for operational runbook support.
+
+Task 6.3 adds:
+- Schema validation tests (payload field constraints, instrument allow-list)
+- Query performance tests (filter correctness under timed assertions)
+- Collection lifecycle: delete, recreate, verify empty
+
+All Qdrant calls are mocked — no live instance required.
+Integration tests that need a real Qdrant are marked @pytest.mark.integration.
+
+Requirements: FR-RAG-1 (Historical Setup Storage), FR-RAG-2 (Semantic Retrieval),
+              NFR-RAG-2 (Scalability)
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from qdrant_client.http import models as qmodels
+
+from services.algorag.config import QdrantConfig
+from services.algorag.qdrant_client import (
+    INDEXED_FIELDS,
+    VECTOR_DIM,
+    QdrantClientWrapper,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers / shared fixtures
+# ---------------------------------------------------------------------------
+
+EXPECTED_INDEXED_FIELDS = frozenset(
+    {"instrument", "time_window", "htf_open_bias", "outcome_result"}
+)
+
+
+def make_config(**overrides) -> QdrantConfig:
+    defaults = dict(
+        host="localhost",
+        port=6333,
+        collection="test_collection",
+        timeout=5.0,
+        max_retries=3,
+        retry_backoff=0.0,
+    )
+    defaults.update(overrides)
+    return QdrantConfig(**defaults)
+
+
+@pytest.fixture()
+def config():
+    return make_config()
+
+
+@pytest.fixture()
+def wrapper(config):
+    return QdrantClientWrapper(config=config)
+
+
+@pytest.fixture()
+def mock_client():
+    """Fully mocked AsyncQdrantClient – collection exists by default."""
+    client = AsyncMock()
+
+    # get_collection success (collection exists)
+    collection_info = MagicMock()
+    collection_info.points_count = 0
+    client.get_collection = AsyncMock(return_value=collection_info)
+
+    client.get_collections = AsyncMock(return_value=MagicMock())
+    client.create_collection = AsyncMock(return_value=None)
+    client.create_payload_index = AsyncMock(return_value=None)
+    client.delete_collection = AsyncMock(return_value=None)
+    client.close = AsyncMock(return_value=None)
+    return client
+
+
+@pytest.fixture()
+def mock_client_absent(mock_client):
+    """Mock where the collection does NOT exist yet."""
+    mock_client.get_collection = AsyncMock(
+        side_effect=Exception("Collection not found")
+    )
+    return mock_client
+
+
+# ---------------------------------------------------------------------------
+# Task 6.1  –  Collection schema and creation
+# ---------------------------------------------------------------------------
+
+
+class TestCollectionSchema:
+    """Verify schema details of the trading_setups collection."""
+
+    # ------------------------------------------------------------------ RED
+    @pytest.mark.asyncio
+    async def test_vector_dimension_is_528(self, wrapper, mock_client_absent):
+        """Collection vectors must be exactly 528-dimensional."""
+        wrapper._client = mock_client_absent
+
+        await wrapper.ensure_collection()
+
+        call_kwargs = mock_client_absent.create_collection.call_args.kwargs
+        assert call_kwargs["vectors_config"].size == VECTOR_DIM
+        assert VECTOR_DIM == 528
+
+    @pytest.mark.asyncio
+    async def test_distance_metric_is_cosine(self, wrapper, mock_client_absent):
+        """Distance metric must be cosine (required by design doc)."""
+        wrapper._client = mock_client_absent
+
+        await wrapper.ensure_collection()
+
+        call_kwargs = mock_client_absent.create_collection.call_args.kwargs
+        assert call_kwargs["vectors_config"].distance == qmodels.Distance.COSINE
+
+    @pytest.mark.asyncio
+    async def test_collection_name_from_config(self, wrapper, mock_client_absent):
+        """Collection is created with the name specified in QdrantConfig."""
+        wrapper._client = mock_client_absent
+
+        await wrapper.ensure_collection()
+
+        call_kwargs = mock_client_absent.create_collection.call_args.kwargs
+        assert call_kwargs["collection_name"] == wrapper._config.collection
+
+    @pytest.mark.asyncio
+    async def test_payload_schema_includes_required_fields(
+        self, wrapper, mock_client_absent
+    ):
+        """
+        After collection creation, payload indexes must be created for:
+        instrument, time_window, htf_open_bias, outcome_result.
+
+        These fields match the EnrichedSetup / Qdrant payload schema described
+        in the design doc (FR-RAG-1, FR-RAG-2).
+        """
+        wrapper._client = mock_client_absent
+
+        await wrapper.ensure_collection()
+
+        indexed = {
+            call.kwargs["field_name"]
+            for call in mock_client_absent.create_payload_index.call_args_list
+        }
+        assert EXPECTED_INDEXED_FIELDS <= indexed, (
+            f"Missing payload indexes: {EXPECTED_INDEXED_FIELDS - indexed}"
+        )
+
+    # ---------------------------------------------------------------- GREEN
+    @pytest.mark.asyncio
+    async def test_idempotent_creation_skips_if_exists(self, wrapper, mock_client):
+        """If the collection already exists, create_collection is never called."""
+        wrapper._client = mock_client
+
+        await wrapper.ensure_collection()
+
+        mock_client.create_collection.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_idempotent_creation_called_once_on_absent(
+        self, wrapper, mock_client_absent
+    ):
+        """create_collection is called exactly once when collection is absent."""
+        wrapper._client = mock_client_absent
+
+        await wrapper.ensure_collection()
+
+        assert mock_client_absent.create_collection.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_ensure_collection_returns_none(self, wrapper, mock_client_absent):
+        """ensure_collection() is fire-and-forget — returns None."""
+        wrapper._client = mock_client_absent
+
+        result = await wrapper.ensure_collection()
+
+        assert result is None
+
+    # -------------------------------------------------------------- REFACTOR
+    @pytest.mark.asyncio
+    async def test_custom_collection_name_override(self, wrapper, mock_client_absent):
+        """ensure_collection() accepts an explicit collection_name override."""
+        wrapper._client = mock_client_absent
+
+        await wrapper.ensure_collection(collection_name="custom_collection")
+
+        call_kwargs = mock_client_absent.create_collection.call_args.kwargs
+        assert call_kwargs["collection_name"] == "custom_collection"
+
+    @pytest.mark.asyncio
+    async def test_custom_vector_size_override(self, wrapper, mock_client_absent):
+        """ensure_collection() accepts an explicit vector_size override."""
+        wrapper._client = mock_client_absent
+
+        await wrapper.ensure_collection(vector_size=256)
+
+        call_kwargs = mock_client_absent.create_collection.call_args.kwargs
+        assert call_kwargs["vectors_config"].size == 256
+
+    def test_indexed_fields_constant_contains_required_fields(self):
+        """INDEXED_FIELDS module constant covers all required filter fields."""
+        assert EXPECTED_INDEXED_FIELDS <= set(INDEXED_FIELDS)
+
+
+# ---------------------------------------------------------------------------
+# Task 6.2  –  Metadata indexing, validation, and rebuild
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataIndexing:
+    """Index creation, validation, and rebuild capability for metadata filtering."""
+
+    # ------------------------------------------------------------------ RED
+    @pytest.mark.asyncio
+    async def test_indexes_created_on_all_four_filter_fields(
+        self, wrapper, mock_client_absent
+    ):
+        """
+        Indexes on instrument, time_window, htf_open_bias, outcome_result are
+        created as KEYWORD schema — required for exact-match metadata filtering
+        in the retrieval pipeline (FR-RAG-2).
+        """
+        wrapper._client = mock_client_absent
+
+        await wrapper.ensure_collection()
+
+        schema_by_field = {
+            call.kwargs["field_name"]: call.kwargs["field_schema"]
+            for call in mock_client_absent.create_payload_index.call_args_list
+        }
+        for field in EXPECTED_INDEXED_FIELDS:
+            assert field in schema_by_field, f"No index created for field '{field}'"
+            assert schema_by_field[field] == qmodels.PayloadSchemaType.KEYWORD, (
+                f"Field '{field}' should use KEYWORD schema for exact-match filtering"
+            )
+
+    @pytest.mark.asyncio
+    async def test_ensure_indexes_creates_missing_indexes(
+        self, wrapper, mock_client
+    ):
+        """
+        ensure_indexes() creates any payload index that does not yet exist.
+        Uses create_payload_index with ignore_malformed=False so that data-type
+        conflicts are surfaced early.
+        """
+        wrapper._client = mock_client
+
+        await wrapper.ensure_indexes()
+
+        created_fields = {
+            call.kwargs["field_name"]
+            for call in mock_client.create_payload_index.call_args_list
+        }
+        assert EXPECTED_INDEXED_FIELDS <= created_fields
+
+    @pytest.mark.asyncio
+    async def test_ensure_indexes_uses_keyword_schema(self, wrapper, mock_client):
+        """ensure_indexes() always uses KEYWORD schema for all filter fields."""
+        wrapper._client = mock_client
+
+        await wrapper.ensure_indexes()
+
+        for call in mock_client.create_payload_index.call_args_list:
+            assert call.kwargs["field_schema"] == qmodels.PayloadSchemaType.KEYWORD
+
+    # ---------------------------------------------------------------- GREEN
+    @pytest.mark.asyncio
+    async def test_validate_indexes_returns_true_when_all_present(
+        self, wrapper, mock_client
+    ):
+        """
+        validate_indexes() returns True when all expected indexes are confirmed
+        present in the collection info.
+        """
+        # Build a mock collection info with all 4 fields indexed
+        indexed_info = {
+            field: MagicMock() for field in EXPECTED_INDEXED_FIELDS
+        }
+        collection_info = MagicMock()
+        collection_info.payload_schema = indexed_info
+        mock_client.get_collection = AsyncMock(return_value=collection_info)
+        wrapper._client = mock_client
+
+        result = await wrapper.validate_indexes()
+
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_validate_indexes_returns_false_when_index_missing(
+        self, wrapper, mock_client
+    ):
+        """
+        validate_indexes() returns False when one or more expected indexes are
+        absent from the collection's payload schema.
+        """
+        # Only 2 of the 4 required fields are indexed
+        partial_indexed = {
+            "instrument": MagicMock(),
+            "time_window": MagicMock(),
+        }
+        collection_info = MagicMock()
+        collection_info.payload_schema = partial_indexed
+        mock_client.get_collection = AsyncMock(return_value=collection_info)
+        wrapper._client = mock_client
+
+        result = await wrapper.validate_indexes()
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_validate_indexes_returns_false_on_error(
+        self, wrapper, mock_client
+    ):
+        """validate_indexes() returns False (not raises) on any Qdrant error."""
+        mock_client.get_collection = AsyncMock(
+            side_effect=Exception("Collection gone")
+        )
+        wrapper._client = mock_client
+
+        result = await wrapper.validate_indexes()
+
+        assert result is False
+
+    # -------------------------------------------------------------- REFACTOR
+    @pytest.mark.asyncio
+    async def test_rebuild_indexes_drops_and_recreates(self, wrapper, mock_client):
+        """
+        rebuild_indexes() calls ensure_indexes() to (re)create all indexes.
+        This supports operational runbook step: rebuild after schema migration.
+        """
+        wrapper._client = mock_client
+
+        await wrapper.rebuild_indexes()
+
+        created_fields = {
+            call.kwargs["field_name"]
+            for call in mock_client.create_payload_index.call_args_list
+        }
+        assert EXPECTED_INDEXED_FIELDS <= created_fields
+
+    @pytest.mark.asyncio
+    async def test_rebuild_indexes_idempotent(self, wrapper, mock_client):
+        """Calling rebuild_indexes() twice does not raise."""
+        wrapper._client = mock_client
+
+        await wrapper.rebuild_indexes()
+        mock_client.create_payload_index.reset_mock()
+        await wrapper.rebuild_indexes()
+
+        # Second call should still attempt to create indexes
+        assert mock_client.create_payload_index.called
+
+    @pytest.mark.asyncio
+    async def test_rebuild_indexes_uses_correct_collection(self, wrapper, mock_client):
+        """rebuild_indexes() targets the collection from config."""
+        wrapper._client = mock_client
+
+        await wrapper.rebuild_indexes()
+
+        for call in mock_client.create_payload_index.call_args_list:
+            assert call.kwargs["collection_name"] == wrapper._config.collection
+
+
+# ---------------------------------------------------------------------------
+# 6.3 (optional)  –  Collection lifecycle tests
+# ---------------------------------------------------------------------------
+
+
+class TestCollectionLifecycle:
+    """Collection creation, deletion, recreation — supports operational tooling."""
+
+    @pytest.mark.asyncio
+    async def test_collection_can_be_deleted_and_recreated(
+        self, wrapper, mock_client
+    ):
+        """
+        delete_collection() followed by ensure_collection() recreates everything.
+        Useful for test teardown and data refresh runbooks.
+        """
+        wrapper._client = mock_client
+        # After deletion the collection no longer exists
+        mock_client.delete_collection = AsyncMock(return_value=None)
+        mock_client.get_collection = AsyncMock(
+            side_effect=Exception("Collection not found")
+        )
+
+        await wrapper.delete_collection()
+        await wrapper.ensure_collection()
+
+        mock_client.delete_collection.assert_called_once_with(
+            collection_name=wrapper._config.collection
+        )
+        mock_client.create_collection.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_delete_collection_uses_config_name(self, wrapper, mock_client):
+        """delete_collection() deletes the collection named in config."""
+        wrapper._client = mock_client
+
+        await wrapper.delete_collection()
+
+        mock_client.delete_collection.assert_called_once_with(
+            collection_name=wrapper._config.collection
+        )
+
+
+# ---------------------------------------------------------------------------
+# Task 6.3 (new) – Schema validation
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaValidation:
+    """
+    Validate that the collection schema enforces payload shape constraints.
+
+    Tests here verify that the wrapper builds PointStruct payloads with the
+    exact fields defined in the Qdrant collection schema (design doc) and that
+    the IngestionRequest validator rejects malformed data before it reaches
+    Qdrant.  All schema checks are exercised in isolation with mocked clients.
+
+    Requirements: FR-RAG-1, NFR-RAG-2
+    """
+
+    def test_vector_dim_constant_is_528(self):
+        """Module-level VECTOR_DIM constant must equal 528."""
+        assert VECTOR_DIM == 528
+
+    def test_indexed_fields_is_non_empty_tuple(self):
+        """INDEXED_FIELDS must be a non-empty sequence of strings."""
+        assert len(INDEXED_FIELDS) > 0
+        for field in INDEXED_FIELDS:
+            assert isinstance(field, str)
+
+    def test_indexed_fields_has_no_duplicates(self):
+        """Each field in INDEXED_FIELDS is unique."""
+        assert len(INDEXED_FIELDS) == len(set(INDEXED_FIELDS))
+
+    def test_required_payload_fields_covered(self):
+        """
+        The four filterable payload fields from the design doc are all present
+        in INDEXED_FIELDS: instrument, time_window, htf_open_bias, outcome_result.
+        """
+        required = {"instrument", "time_window", "htf_open_bias", "outcome_result"}
+        assert required <= set(INDEXED_FIELDS)
+
+    def test_ingestion_request_rejects_wrong_embedding_dim(self):
+        """IngestionRequest must raise ValueError for non-528 embeddings."""
+        from pydantic import ValidationError
+
+        from services.algorag.models import IngestionRequest
+
+        with pytest.raises(ValidationError):
+            IngestionRequest(
+                setup={"trade_id": "TRD-001"},
+                embedding=[0.0] * 256,  # wrong size
+            )
+
+    def test_ingestion_request_rejects_empty_embedding(self):
+        """IngestionRequest must reject an empty embedding list."""
+        from pydantic import ValidationError
+
+        from services.algorag.models import IngestionRequest
+
+        with pytest.raises(ValidationError):
+            IngestionRequest(
+                setup={"trade_id": "TRD-002"},
+                embedding=[],
+            )
+
+    def test_ingestion_request_accepts_528_dim_embedding(self):
+        """IngestionRequest accepts a valid 528-dim embedding without error."""
+        from services.algorag.models import IngestionRequest
+
+        req = IngestionRequest(
+            setup={"trade_id": "TRD-003"},
+            embedding=[0.1] * 528,
+        )
+        assert len(req.embedding) == 528
+
+    def test_retrieval_request_uppercases_instrument(self):
+        """RetrievalRequest normalises instrument to uppercase (FR-RAG-2)."""
+        from datetime import datetime, timezone
+
+        from services.algorag.models import RetrievalRequest
+
+        req = RetrievalRequest(
+            instrument="eurusd",
+            timestamp=datetime.now(tz=timezone.utc),
+        )
+        assert req.instrument == "EURUSD"
+
+    def test_rag_metrics_win_rate_bounded(self):
+        """RAGMetrics.win_rate_similar must be in [0.0, 1.0]."""
+        from pydantic import ValidationError
+
+        from services.algorag.models import RAGMetrics
+
+        with pytest.raises(ValidationError):
+            RAGMetrics(
+                avg_r_multiple_similar=2.0,
+                win_rate_similar=1.5,  # out of range
+                sample_size=5,
+                max_similarity_score=0.9,
+                avg_confluence_count=3.0,
+            )
+
+    def test_rag_metrics_similarity_score_bounded(self):
+        """RAGMetrics.max_similarity_score must be in [0.0, 1.0]."""
+        from pydantic import ValidationError
+
+        from services.algorag.models import RAGMetrics
+
+        with pytest.raises(ValidationError):
+            RAGMetrics(
+                avg_r_multiple_similar=2.0,
+                win_rate_similar=0.8,
+                sample_size=5,
+                max_similarity_score=-0.1,  # out of range
+                avg_confluence_count=3.0,
+            )
+
+    def test_similar_setup_similarity_score_bounded(self):
+        """SimilarSetup similarity_score must be in [0.0, 1.0]."""
+        from datetime import datetime, timezone
+
+        from pydantic import ValidationError
+
+        from services.algorag.models import SimilarSetup
+
+        with pytest.raises(ValidationError):
+            SimilarSetup(
+                trade_id="TRD-X",
+                timestamp=datetime.now(tz=timezone.utc),
+                instrument="EURUSD",
+                time_window="LONDON_KILLZONE",
+                htf_open_bias="BULLISH",
+                confluence_count=3,
+                outcome_result="WIN",
+                outcome_r_multiple=2.5,
+                narrative="test",
+                similarity_score=1.5,  # out of range
+                final_score=0.9,
+            )
+
+    def test_point_struct_shape_matches_schema(self):
+        """
+        A PointStruct built for the trading_setups collection must carry all
+        required payload keys from the Qdrant schema in the design doc.
+        """
+        required_payload_keys = {
+            "trade_id",
+            "timestamp",
+            "instrument",
+            "time_window",
+            "htf_open_bias",
+            "confluence_count",
+            "outcome_result",
+            "outcome_r_multiple",
+            "narrative",
+        }
+        payload = {
+            "trade_id": "TRD-001",
+            "timestamp": "2024-03-15T09:15:00Z",
+            "instrument": "EURUSD",
+            "time_window": "LONDON_KILLZONE",
+            "htf_open_bias": "BULLISH",
+            "confluence_count": 4,
+            "outcome_result": "WIN",
+            "outcome_r_multiple": 3.2,
+            "narrative": "Price swept Asian low and entered FVG",
+            "full_setup": {},
+        }
+        point = qmodels.PointStruct(
+            id="abc-123",
+            vector=[0.0] * VECTOR_DIM,
+            payload=payload,
+        )
+        assert required_payload_keys <= set(point.payload.keys())
+
+
+# ---------------------------------------------------------------------------
+# Task 6.3 (new) – Query performance
+# ---------------------------------------------------------------------------
+
+
+class TestQueryPerformance:
+    """
+    Verify that filter construction and search mechanics behave correctly,
+    and that mocked round-trips complete well within the p95 latency budget
+    (< 100ms per FR-RAG-2 / NFR-RAG-1).
+
+    Performance numbers here are for the mock path only — real Qdrant
+    latency is validated by the integration tests below.
+    """
+
+    @pytest.mark.asyncio
+    async def test_search_with_instrument_filter_passes_correct_condition(
+        self, wrapper, mock_client
+    ):
+        """
+        When searching with an instrument filter the wrapper must include a
+        FieldCondition(key='instrument', match=MatchValue(value=...)) in the
+        must clause — matching the retrieval pipeline design (FR-RAG-2).
+        """
+        wrapper._client = mock_client
+        mock_client.search = AsyncMock(return_value=[])
+
+        qdrant_filter = qmodels.Filter(
+            must=[
+                qmodels.FieldCondition(
+                    key="instrument",
+                    match=qmodels.MatchValue(value="EURUSD"),
+                )
+            ]
+        )
+        await wrapper.search(
+            query_vector=[0.0] * VECTOR_DIM,
+            query_filter=qdrant_filter,
+            limit=10,
+        )
+
+        call_kwargs = mock_client.search.call_args.kwargs
+        assert call_kwargs["query_filter"] is qdrant_filter
+        assert call_kwargs["limit"] == 10
+
+    @pytest.mark.asyncio
+    async def test_search_with_composite_filter_passes_all_conditions(
+        self, wrapper, mock_client
+    ):
+        """
+        Composite filters (instrument + time_window + outcome) are forwarded
+        to Qdrant intact.  The wrapper must not strip or modify the filter
+        object — metadata filtering happens server-side (FR-RAG-2).
+        """
+        wrapper._client = mock_client
+        mock_client.search = AsyncMock(return_value=[])
+
+        composite_filter = qmodels.Filter(
+            must=[
+                qmodels.FieldCondition(
+                    key="instrument", match=qmodels.MatchValue(value="GBPUSD")
+                ),
+                qmodels.FieldCondition(
+                    key="time_window",
+                    match=qmodels.MatchValue(value="NY_KILLZONE"),
+                ),
+                qmodels.FieldCondition(
+                    key="outcome_result", match=qmodels.MatchValue(value="WIN")
+                ),
+            ]
+        )
+        await wrapper.search(
+            query_vector=[0.0] * VECTOR_DIM,
+            query_filter=composite_filter,
+        )
+
+        call_kwargs = mock_client.search.call_args.kwargs
+        passed_filter = call_kwargs["query_filter"]
+        field_keys = {c.key for c in passed_filter.must}
+        assert field_keys == {"instrument", "time_window", "outcome_result"}
+
+    @pytest.mark.asyncio
+    async def test_search_without_filter_passes_none(self, wrapper, mock_client):
+        """
+        When no filter is provided the wrapper passes query_filter=None, allowing
+        Qdrant to scan the full collection (useful for recall benchmarks).
+        """
+        wrapper._client = mock_client
+        mock_client.search = AsyncMock(return_value=[])
+
+        await wrapper.search(query_vector=[0.0] * VECTOR_DIM)
+
+        call_kwargs = mock_client.search.call_args.kwargs
+        assert call_kwargs.get("query_filter") is None
+
+    @pytest.mark.asyncio
+    async def test_search_default_limit_is_ten(self, wrapper, mock_client):
+        """
+        The default retrieval candidate pool is 10 (top-k before re-ranking).
+        This matches the design doc retrieval pipeline.
+        """
+        wrapper._client = mock_client
+        mock_client.search = AsyncMock(return_value=[])
+
+        await wrapper.search(query_vector=[0.0] * VECTOR_DIM)
+
+        call_kwargs = mock_client.search.call_args.kwargs
+        assert call_kwargs["limit"] == 10
+
+    @pytest.mark.asyncio
+    async def test_search_with_payload_enabled(self, wrapper, mock_client):
+        """
+        Search must request full payloads (with_payload=True) so the caller
+        receives trade_id, narrative, outcome, etc. without a second round-trip.
+        """
+        wrapper._client = mock_client
+        mock_client.search = AsyncMock(return_value=[])
+
+        await wrapper.search(query_vector=[0.0] * VECTOR_DIM)
+
+        call_kwargs = mock_client.search.call_args.kwargs
+        assert call_kwargs.get("with_payload") is True
+
+    @pytest.mark.asyncio
+    async def test_mocked_search_completes_under_1ms(self, wrapper, mock_client):
+        """
+        Mocked search (no I/O) must complete in < 1 ms.  This baseline test
+        confirms the wrapper overhead alone is negligible — latency in real
+        scenarios is dominated by network + Qdrant ANN, tested via integration.
+
+        NFR-RAG-1 requires p95 < 100ms; this test guards the wrapper path.
+        """
+        wrapper._client = mock_client
+        mock_client.search = AsyncMock(return_value=[])
+
+        start = time.perf_counter()
+        await wrapper.search(query_vector=[0.0] * VECTOR_DIM)
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        assert elapsed_ms < 1.0, (
+            f"Mock search took {elapsed_ms:.2f}ms — wrapper overhead is too high"
+        )
+
+    @pytest.mark.asyncio
+    async def test_mocked_ensure_collection_completes_under_5ms(
+        self, wrapper, mock_client_absent
+    ):
+        """
+        Collection creation (mocked) must complete in < 5 ms.  Guards wrapper
+        startup overhead independently of Qdrant I/O.
+        """
+        wrapper._client = mock_client_absent
+
+        start = time.perf_counter()
+        await wrapper.ensure_collection()
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        assert elapsed_ms < 5.0, (
+            f"Mock ensure_collection took {elapsed_ms:.2f}ms — too slow"
+        )
+
+    @pytest.mark.asyncio
+    async def test_mocked_ensure_indexes_completes_under_5ms(
+        self, wrapper, mock_client
+    ):
+        """
+        Index creation for all four fields (mocked) must complete in < 5 ms.
+        """
+        wrapper._client = mock_client
+
+        start = time.perf_counter()
+        await wrapper.ensure_indexes()
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        assert elapsed_ms < 5.0, (
+            f"Mock ensure_indexes took {elapsed_ms:.2f}ms — too slow"
+        )
+
+    @pytest.mark.asyncio
+    async def test_mocked_upsert_100_points_completes_under_10ms(
+        self, wrapper, mock_client
+    ):
+        """
+        Batch upsert of 100 PointStructs (mocked) must complete in < 10 ms.
+        Validates that the wrapper does not iterate points individually.
+        """
+        wrapper._client = mock_client
+        mock_client.upsert = AsyncMock(return_value=None)
+
+        points = [
+            qmodels.PointStruct(
+                id=str(i),
+                vector=[float(i % 100) / 100.0] * VECTOR_DIM,
+                payload={"instrument": "EURUSD"},
+            )
+            for i in range(100)
+        ]
+
+        start = time.perf_counter()
+        await wrapper.upsert(points)
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        assert elapsed_ms < 10.0, (
+            f"Mock upsert of 100 points took {elapsed_ms:.2f}ms — too slow"
+        )
+
+    @pytest.mark.asyncio
+    async def test_search_uses_config_collection_name(self, wrapper, mock_client):
+        """
+        All search calls target the collection specified in QdrantConfig, never
+        a hard-coded string.  Collection name isolation is required for
+        multi-environment deployments (dev / staging / prod).
+        """
+        wrapper._client = mock_client
+        mock_client.search = AsyncMock(return_value=[])
+
+        await wrapper.search(query_vector=[0.0] * VECTOR_DIM)
+
+        call_kwargs = mock_client.search.call_args.kwargs
+        assert call_kwargs["collection_name"] == wrapper._config.collection
+
+    @pytest.mark.asyncio
+    async def test_validate_indexes_completes_under_1ms(
+        self, wrapper, mock_client
+    ):
+        """
+        validate_indexes() (mocked) must complete in < 1 ms so it can be
+        called on every health-check poll without adding measurable overhead.
+        """
+        indexed_info = {field: MagicMock() for field in INDEXED_FIELDS}
+        collection_info = MagicMock()
+        collection_info.payload_schema = indexed_info
+        mock_client.get_collection = AsyncMock(return_value=collection_info)
+        wrapper._client = mock_client
+
+        start = time.perf_counter()
+        await wrapper.validate_indexes()
+        elapsed_ms = (time.perf_counter() - start) * 1000
+
+        assert elapsed_ms < 1.0, (
+            f"Mock validate_indexes took {elapsed_ms:.2f}ms — too slow"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (require live Qdrant on localhost:6333)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestCollectionManagementIntegration:
+    """Full end-to-end collection management against a live Qdrant instance."""
+
+    @pytest.mark.asyncio
+    async def test_live_collection_creation_idempotent(self):
+        cfg = make_config(
+            collection="test_task6_collection",
+            retry_backoff=0.1,
+        )
+        wrapper = QdrantClientWrapper(config=cfg)
+        try:
+            # First call creates
+            await wrapper.ensure_collection()
+            # Second call must not raise
+            await wrapper.ensure_collection()
+            count = await wrapper.count()
+            assert isinstance(count, int)
+        finally:
+            await wrapper.delete_collection()
+            await wrapper.close()
+
+    @pytest.mark.asyncio
+    async def test_live_indexes_valid_after_ensure(self):
+        cfg = make_config(
+            collection="test_task6_indexes",
+            retry_backoff=0.1,
+        )
+        wrapper = QdrantClientWrapper(config=cfg)
+        try:
+            await wrapper.ensure_collection()
+            is_valid = await wrapper.validate_indexes()
+            assert is_valid is True
+        finally:
+            await wrapper.delete_collection()
+            await wrapper.close()
+
+    @pytest.mark.asyncio
+    async def test_live_rebuild_indexes_after_partial_setup(self):
+        cfg = make_config(
+            collection="test_task6_rebuild",
+            retry_backoff=0.1,
+        )
+        wrapper = QdrantClientWrapper(config=cfg)
+        try:
+            await wrapper.ensure_collection()
+            # rebuild should be idempotent on a healthy collection
+            await wrapper.rebuild_indexes()
+            is_valid = await wrapper.validate_indexes()
+            assert is_valid is True
+        finally:
+            await wrapper.delete_collection()
+            await wrapper.close()
+
+    @pytest.mark.asyncio
+    async def test_live_delete_and_recreate_collection(self):
+        """Delete, then recreate — collection comes back empty with all indexes."""
+        cfg = make_config(
+            collection="test_task6_lifecycle",
+            retry_backoff=0.1,
+        )
+        wrapper = QdrantClientWrapper(config=cfg)
+        try:
+            await wrapper.ensure_collection()
+            count_before = await wrapper.count()
+            await wrapper.delete_collection()
+
+            # Recreate
+            await wrapper.ensure_collection()
+            count_after = await wrapper.count()
+
+            assert isinstance(count_before, int)
+            assert count_after == 0  # fresh collection
+
+            is_valid = await wrapper.validate_indexes()
+            assert is_valid is True
+        finally:
+            await wrapper.delete_collection()
+            await wrapper.close()
+
+    @pytest.mark.asyncio
+    async def test_live_search_latency_p95_under_100ms(self):
+        """
+        Retrieval p95 latency must be < 100ms against a live empty collection
+        (NFR-RAG-1).  Runs 20 searches and checks the 95th-percentile.
+        """
+        import statistics
+
+        cfg = make_config(
+            collection="test_task6_latency",
+            retry_backoff=0.1,
+        )
+        wrapper = QdrantClientWrapper(config=cfg)
+        try:
+            await wrapper.ensure_collection()
+
+            latencies = []
+            for _ in range(20):
+                t0 = time.perf_counter()
+                await wrapper.search(
+                    query_vector=[0.0] * VECTOR_DIM,
+                    limit=10,
+                )
+                latencies.append((time.perf_counter() - t0) * 1000)
+
+            latencies.sort()
+            p95 = latencies[int(len(latencies) * 0.95)]
+            assert p95 < 100.0, (
+                f"Live search p95 latency {p95:.1f}ms exceeds 100ms budget (NFR-RAG-1)"
+            )
+        finally:
+            await wrapper.delete_collection()
+            await wrapper.close()

--- a/services/algorag/tests/test_ingestion_service.py
+++ b/services/algorag/tests/test_ingestion_service.py
@@ -1,0 +1,731 @@
+"""
+TDD – Task 7: Setup ingestion to vector store.
+
+Task 7.1 – Create ingestion service
+    RED  phase: tests for batch ingestion of enriched setups with embeddings to Qdrant.
+    GREEN phase: implement batch upsert with error handling and retry logic.
+    REFACTOR: add progress tracking and logging.
+
+Task 7.2 – Implement duplicate detection
+    RED  phase: tests for detection and handling of duplicate trade_ids.
+    GREEN phase: implement upsert logic (update if exists, insert if new).
+    REFACTOR: add conflict resolution strategy.
+
+All Qdrant calls are mocked — no live instance required.
+Integration tests that require a real Qdrant instance are marked
+@pytest.mark.integration and are skipped by default.
+
+Requirements: FR-RAG-1 (Historical Setup Storage), FR-RAG-7 (Real-Time Ingestion)
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import numpy as np
+import pytest
+from qdrant_client.http import models as qmodels
+
+from services.algorag.config import QdrantConfig
+from services.algorag.ingestion_service import (
+    EMBEDDING_DIM,
+    BatchIngestionResult,
+    DuplicateStrategy,
+    IngestionService,
+    IngestionServiceError,
+    build_point_from_setup,
+)
+from services.algorag.qdrant_client import QdrantClientWrapper
+
+
+# ---------------------------------------------------------------------------
+# Helpers / shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def make_config(**overrides) -> QdrantConfig:
+    defaults = dict(
+        host="localhost",
+        port=6333,
+        collection="test_trading_setups",
+        timeout=5.0,
+        max_retries=3,
+        retry_backoff=0.0,
+    )
+    defaults.update(overrides)
+    return QdrantConfig(**defaults)
+
+
+def make_enriched_setup(trade_id: str = "TRD-001", **overrides) -> Dict[str, Any]:
+    """Minimal valid enriched setup matching the EnrichedSetup schema."""
+    base = {
+        "trade_id": trade_id,
+        "timestamp": "2024-03-15T09:15:00Z",
+        "instrument": "EURUSD",
+        "direction": "LONG",
+        "time_window": "LONDON_KILLZONE",
+        "htf_open_bias": "BULLISH",
+        "confluence_count": 4,
+        "outcome_result": "WIN",
+        "outcome_r_multiple": 3.2,
+        "narrative": "Price swept Asian low and entered FVG at discount.",
+        "bos_detected": True,
+        "choch_detected": False,
+        "fvg_present": True,
+        "liquidity_sweep": True,
+        "htf_high_proximity_pct": 0.35,
+        "htf_low_proximity_pct": 0.65,
+    }
+    base.update(overrides)
+    return base
+
+
+def make_embedding(dim: int = 528) -> List[float]:
+    """Return a deterministic 528-dim embedding vector."""
+    rng = np.random.default_rng(42)
+    return rng.standard_normal(dim).tolist()
+
+
+@pytest.fixture()
+def config() -> QdrantConfig:
+    return make_config()
+
+
+@pytest.fixture()
+def mock_qdrant_wrapper() -> QdrantClientWrapper:
+    """QdrantClientWrapper with all async methods mocked."""
+    wrapper = MagicMock(spec=QdrantClientWrapper)
+    wrapper.upsert = AsyncMock(return_value=None)
+    wrapper.count = AsyncMock(return_value=10)
+    wrapper.is_healthy = AsyncMock(return_value=True)
+    return wrapper
+
+
+@pytest.fixture()
+def service(config: QdrantConfig, mock_qdrant_wrapper: QdrantClientWrapper) -> IngestionService:
+    """IngestionService with a mocked Qdrant client."""
+    return IngestionService(wrapper=mock_qdrant_wrapper, config=config)
+
+
+# ---------------------------------------------------------------------------
+# Task 7.1 – Batch ingestion
+# ---------------------------------------------------------------------------
+
+
+class TestBatchIngestionRED:
+    """
+    RED phase: tests that describe the desired batch ingestion behaviour.
+    These tests define the contract for IngestionService.ingest_batch().
+    Requirements: FR-RAG-1, FR-RAG-7
+    """
+
+    @pytest.mark.asyncio
+    async def test_ingest_single_setup_calls_upsert(
+        self, service: IngestionService, mock_qdrant_wrapper: QdrantClientWrapper
+    ) -> None:
+        """ingest_batch() with a single setup must call upsert exactly once."""
+        setup = make_enriched_setup()
+        embedding = make_embedding()
+
+        result = await service.ingest_batch([(setup, embedding)])
+
+        mock_qdrant_wrapper.upsert.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ingest_batch_passes_correct_collection(
+        self, service: IngestionService, mock_qdrant_wrapper: QdrantClientWrapper, config: QdrantConfig
+    ) -> None:
+        """ingest_batch() must target the collection from config."""
+        setup = make_enriched_setup()
+        embedding = make_embedding()
+
+        await service.ingest_batch([(setup, embedding)])
+
+        call_kwargs = mock_qdrant_wrapper.upsert.call_args.kwargs
+        assert call_kwargs.get("collection_name") == config.collection
+
+    @pytest.mark.asyncio
+    async def test_ingest_batch_returns_result_object(
+        self, service: IngestionService
+    ) -> None:
+        """ingest_batch() returns a BatchIngestionResult with counts."""
+        setups = [(make_enriched_setup(f"TRD-{i:03d}"), make_embedding()) for i in range(5)]
+
+        result = await service.ingest_batch(setups)
+
+        assert isinstance(result, BatchIngestionResult)
+
+    @pytest.mark.asyncio
+    async def test_ingest_batch_reports_success_count(
+        self, service: IngestionService
+    ) -> None:
+        """BatchIngestionResult.successful equals the number of ingested setups."""
+        n = 5
+        setups = [(make_enriched_setup(f"TRD-{i:03d}"), make_embedding()) for i in range(n)]
+
+        result = await service.ingest_batch(setups)
+
+        assert result.successful == n
+
+    @pytest.mark.asyncio
+    async def test_ingest_batch_reports_zero_failures_on_success(
+        self, service: IngestionService
+    ) -> None:
+        """BatchIngestionResult.failed equals 0 when all setups are ingested."""
+        setups = [(make_enriched_setup(f"TRD-{i:03d}"), make_embedding()) for i in range(3)]
+
+        result = await service.ingest_batch(setups)
+
+        assert result.failed == 0
+
+    @pytest.mark.asyncio
+    async def test_ingest_batch_multiple_setups_single_upsert_call(
+        self, service: IngestionService, mock_qdrant_wrapper: QdrantClientWrapper
+    ) -> None:
+        """
+        Batch ingestion of N setups must dispatch a single upsert call with
+        all N PointStructs, not N individual upsert calls.
+        This is the key performance requirement for bulk ingestion.
+        """
+        n = 10
+        setups = [(make_enriched_setup(f"TRD-{i:03d}"), make_embedding()) for i in range(n)]
+
+        await service.ingest_batch(setups)
+
+        assert mock_qdrant_wrapper.upsert.call_count == 1
+        call_kwargs = mock_qdrant_wrapper.upsert.call_args.kwargs
+        assert len(call_kwargs["points"]) == n
+
+    @pytest.mark.asyncio
+    async def test_ingest_batch_point_has_correct_embedding(
+        self, service: IngestionService, mock_qdrant_wrapper: QdrantClientWrapper
+    ) -> None:
+        """Each PointStruct vector must match the provided embedding."""
+        embedding = make_embedding()
+        await service.ingest_batch([(make_enriched_setup(), embedding)])
+
+        points = mock_qdrant_wrapper.upsert.call_args.kwargs["points"]
+        assert points[0].vector == embedding
+
+    @pytest.mark.asyncio
+    async def test_ingest_batch_point_has_required_payload_keys(
+        self, service: IngestionService, mock_qdrant_wrapper: QdrantClientWrapper
+    ) -> None:
+        """Each PointStruct payload must include all schema-required keys."""
+        required_keys = {
+            "trade_id",
+            "timestamp",
+            "instrument",
+            "time_window",
+            "htf_open_bias",
+            "confluence_count",
+            "outcome_result",
+            "outcome_r_multiple",
+            "narrative",
+        }
+        await service.ingest_batch([(make_enriched_setup(), make_embedding())])
+
+        points = mock_qdrant_wrapper.upsert.call_args.kwargs["points"]
+        assert required_keys <= set(points[0].payload.keys())
+
+    @pytest.mark.asyncio
+    async def test_ingest_batch_instrument_stored_uppercase(
+        self, service: IngestionService, mock_qdrant_wrapper: QdrantClientWrapper
+    ) -> None:
+        """Instrument must be stored as uppercase in the payload (project convention)."""
+        setup = make_enriched_setup(instrument="eurusd")
+        await service.ingest_batch([(setup, make_embedding())])
+
+        points = mock_qdrant_wrapper.upsert.call_args.kwargs["points"]
+        assert points[0].payload["instrument"] == "EURUSD"
+
+    @pytest.mark.asyncio
+    async def test_ingest_empty_batch_returns_zero_counts(
+        self, service: IngestionService, mock_qdrant_wrapper: QdrantClientWrapper
+    ) -> None:
+        """Ingesting an empty list returns a result with successful=0, failed=0."""
+        result = await service.ingest_batch([])
+
+        assert result.successful == 0
+        assert result.failed == 0
+        mock_qdrant_wrapper.upsert.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ingest_batch_full_setup_stored_in_payload(
+        self, service: IngestionService, mock_qdrant_wrapper: QdrantClientWrapper
+    ) -> None:
+        """The full setup dict must be stored under the 'full_setup' payload key."""
+        setup = make_enriched_setup(trade_id="TRD-FULL")
+        await service.ingest_batch([(setup, make_embedding())])
+
+        points = mock_qdrant_wrapper.upsert.call_args.kwargs["points"]
+        assert "full_setup" in points[0].payload
+        assert points[0].payload["full_setup"]["trade_id"] == "TRD-FULL"
+
+
+class TestBatchIngestionErrorHandlingGREEN:
+    """
+    GREEN phase: error handling and retry logic.
+    Requirements: FR-RAG-1, FR-RAG-7
+    """
+
+    @pytest.mark.asyncio
+    async def test_ingest_batch_raises_ingestion_service_error_on_upsert_failure(
+        self, service: IngestionService, mock_qdrant_wrapper: QdrantClientWrapper
+    ) -> None:
+        """When upsert fails after all retries, IngestionServiceError is raised."""
+        from services.algorag.qdrant_client import QdrantConnectionError
+        mock_qdrant_wrapper.upsert = AsyncMock(side_effect=QdrantConnectionError("timeout"))
+
+        with pytest.raises(IngestionServiceError, match="Batch ingestion failed"):
+            await service.ingest_batch([(make_enriched_setup(), make_embedding())])
+
+    @pytest.mark.asyncio
+    async def test_ingest_batch_partial_failure_records_failed_count(
+        self, service: IngestionService, mock_qdrant_wrapper: QdrantClientWrapper
+    ) -> None:
+        """
+        When the service is configured with small_batch_size, individual-batch
+        failures are counted in result.failed rather than raising immediately.
+        Partial failure allows remaining batches to proceed.
+        """
+        call_count = 0
+        async def flaky_upsert(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise Exception("transient failure")
+
+        mock_qdrant_wrapper.upsert = flaky_upsert
+        # Use small batch size so we get multiple upsert calls
+        service_small = IngestionService(
+            wrapper=mock_qdrant_wrapper,
+            config=make_config(),
+            batch_size=3,
+        )
+        # 7 setups with batch_size=3 → 3 batches, 2nd fails
+        setups = [(make_enriched_setup(f"TRD-{i:03d}"), make_embedding()) for i in range(7)]
+
+        result = await service_small.ingest_batch(setups)
+
+        # 2nd batch of 3 failed, other 2 batches succeeded
+        assert result.failed == 3
+        assert result.successful == 4
+
+    @pytest.mark.asyncio
+    async def test_ingest_batch_invalid_embedding_dimension_raises(
+        self, service: IngestionService
+    ) -> None:
+        """Embeddings with wrong dimension are rejected before hitting Qdrant."""
+        bad_embedding = [0.0] * 256  # wrong size
+
+        with pytest.raises(ValueError, match="528"):
+            await service.ingest_batch([(make_enriched_setup(), bad_embedding)])
+
+    @pytest.mark.asyncio
+    async def test_ingest_batch_missing_trade_id_generates_uuid(
+        self, service: IngestionService, mock_qdrant_wrapper: QdrantClientWrapper
+    ) -> None:
+        """Setup missing trade_id gets a deterministic UUID assigned."""
+        setup_no_id: Dict[str, Any] = {k: v for k, v in make_enriched_setup().items() if k != "trade_id"}
+
+        await service.ingest_batch([(setup_no_id, make_embedding())])
+
+        points = mock_qdrant_wrapper.upsert.call_args.kwargs["points"]
+        assert "trade_id" in points[0].payload
+        assert len(points[0].payload["trade_id"]) > 0
+
+
+class TestProgressTrackingREFACTOR:
+    """
+    REFACTOR phase: progress tracking and logging.
+    Requirements: FR-RAG-1
+    """
+
+    @pytest.mark.asyncio
+    async def test_ingest_batch_result_has_ingested_ids(
+        self, service: IngestionService
+    ) -> None:
+        """BatchIngestionResult.ingested_ids contains a UUID for each ingested setup."""
+        n = 3
+        setups = [(make_enriched_setup(f"TRD-{i:03d}"), make_embedding()) for i in range(n)]
+
+        result = await service.ingest_batch(setups)
+
+        assert len(result.ingested_ids) == n
+        for setup_id in result.ingested_ids:
+            assert isinstance(setup_id, str)
+            assert len(setup_id) > 0
+
+    @pytest.mark.asyncio
+    async def test_ingest_batch_result_has_total_count(
+        self, service: IngestionService
+    ) -> None:
+        """BatchIngestionResult.total equals len(input)."""
+        n = 4
+        setups = [(make_enriched_setup(f"TRD-{i:03d}"), make_embedding()) for i in range(n)]
+
+        result = await service.ingest_batch(setups)
+
+        assert result.total == n
+
+
+# ---------------------------------------------------------------------------
+# Task 7.2 – Duplicate detection
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicateDetectionRED:
+    """
+    RED phase: tests for duplicate trade_id detection and upsert semantics.
+    Requirements: FR-RAG-1
+    """
+
+    def test_build_point_from_setup_generates_deterministic_id(self) -> None:
+        """
+        build_point_from_setup() must produce the same PointStruct UUID for the
+        same trade_id, enabling Qdrant upsert deduplication by point ID.
+        Determinism is essential: ingesting the same trade_id twice must
+        overwrite the existing vector, not create a duplicate.
+        """
+        setup = make_enriched_setup(trade_id="TRD-DET-001")
+        embedding = make_embedding()
+
+        point1 = build_point_from_setup(setup, embedding)
+        point2 = build_point_from_setup(setup, embedding)
+
+        assert point1.id == point2.id
+
+    def test_build_point_different_trade_ids_produce_different_point_ids(self) -> None:
+        """
+        Different trade_ids must produce different PointStruct UUIDs so that
+        distinct setups are stored as separate vectors in Qdrant.
+        """
+        setup_a = make_enriched_setup(trade_id="TRD-001")
+        setup_b = make_enriched_setup(trade_id="TRD-002")
+        embedding = make_embedding()
+
+        point_a = build_point_from_setup(setup_a, embedding)
+        point_b = build_point_from_setup(setup_b, embedding)
+
+        assert point_a.id != point_b.id
+
+    def test_build_point_id_is_uuid5_of_trade_id(self) -> None:
+        """
+        The PointStruct ID must be uuid5(NAMESPACE_DNS, trade_id) — the same
+        deterministic scheme used by the /rag/ingest endpoint (FR-RAG-1).
+        """
+        trade_id = "TRD-UUID5-TEST"
+        expected_id = str(uuid.uuid5(uuid.NAMESPACE_DNS, trade_id))
+        setup = make_enriched_setup(trade_id=trade_id)
+
+        point = build_point_from_setup(setup, make_embedding())
+
+        assert str(point.id) == expected_id
+
+    @pytest.mark.asyncio
+    async def test_ingest_same_trade_id_twice_calls_upsert_twice(
+        self, service: IngestionService, mock_qdrant_wrapper: QdrantClientWrapper
+    ) -> None:
+        """
+        Ingesting the same trade_id in two separate calls both reach Qdrant upsert.
+        Qdrant's upsert semantics handle the actual deduplication server-side —
+        the service must not filter out duplicates client-side.
+        """
+        setup = make_enriched_setup(trade_id="TRD-DUP")
+        embedding = make_embedding()
+
+        await service.ingest_batch([(setup, embedding)])
+        await service.ingest_batch([(setup, embedding)])
+
+        assert mock_qdrant_wrapper.upsert.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_ingest_same_trade_id_twice_same_point_id(
+        self, service: IngestionService, mock_qdrant_wrapper: QdrantClientWrapper
+    ) -> None:
+        """
+        Both upsert calls for the same trade_id must send the same PointStruct ID.
+        Qdrant uses the ID to identify whether to insert or update the record.
+        """
+        setup = make_enriched_setup(trade_id="TRD-SAME-ID")
+        embedding = make_embedding()
+
+        await service.ingest_batch([(setup, embedding)])
+        await service.ingest_batch([(setup, embedding)])
+
+        all_calls = mock_qdrant_wrapper.upsert.call_args_list
+        id_first = all_calls[0].kwargs["points"][0].id
+        id_second = all_calls[1].kwargs["points"][0].id
+
+        assert id_first == id_second
+
+    @pytest.mark.asyncio
+    async def test_ingest_updated_setup_overwrites_payload(
+        self, service: IngestionService, mock_qdrant_wrapper: QdrantClientWrapper
+    ) -> None:
+        """
+        When a trade_id is re-ingested with a different outcome, the new payload
+        must be forwarded to Qdrant (not silently dropped).
+        """
+        setup_v1 = make_enriched_setup(trade_id="TRD-UPDATE", outcome_result="LOSS")
+        setup_v2 = make_enriched_setup(trade_id="TRD-UPDATE", outcome_result="WIN")
+        embedding = make_embedding()
+
+        await service.ingest_batch([(setup_v1, embedding)])
+        await service.ingest_batch([(setup_v2, embedding)])
+
+        last_call_points = mock_qdrant_wrapper.upsert.call_args.kwargs["points"]
+        assert last_call_points[0].payload["outcome_result"] == "WIN"
+
+
+class TestDuplicateStrategyGREEN:
+    """
+    GREEN phase: upsert logic correctness.
+    Requirements: FR-RAG-1
+    """
+
+    def test_default_strategy_is_upsert(self, config: QdrantConfig, mock_qdrant_wrapper: QdrantClientWrapper) -> None:
+        """IngestionService defaults to UPSERT duplicate strategy."""
+        svc = IngestionService(wrapper=mock_qdrant_wrapper, config=config)
+        assert svc.duplicate_strategy == DuplicateStrategy.UPSERT
+
+    def test_service_accepts_custom_duplicate_strategy(
+        self, config: QdrantConfig, mock_qdrant_wrapper: QdrantClientWrapper
+    ) -> None:
+        """IngestionService accepts an explicit DuplicateStrategy at construction."""
+        svc = IngestionService(
+            wrapper=mock_qdrant_wrapper,
+            config=config,
+            duplicate_strategy=DuplicateStrategy.UPSERT,
+        )
+        assert svc.duplicate_strategy == DuplicateStrategy.UPSERT
+
+    @pytest.mark.asyncio
+    async def test_ingest_batch_duplicate_strategy_skip_does_not_overwrite(
+        self, config: QdrantConfig, mock_qdrant_wrapper: QdrantClientWrapper
+    ) -> None:
+        """
+        SKIP strategy: when a trade_id is already known to the service
+        (tracked in-memory per session), it must not be re-sent to Qdrant.
+        """
+        svc = IngestionService(
+            wrapper=mock_qdrant_wrapper,
+            config=config,
+            duplicate_strategy=DuplicateStrategy.SKIP,
+        )
+        setup = make_enriched_setup(trade_id="TRD-SKIP-DUP")
+        embedding = make_embedding()
+
+        # First ingestion: should go through
+        await svc.ingest_batch([(setup, embedding)])
+        # Second ingestion of same trade_id: should be skipped
+        await svc.ingest_batch([(setup, embedding)])
+
+        # Only one upsert call should have been made
+        assert mock_qdrant_wrapper.upsert.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_ingest_batch_skip_strategy_skip_count_in_result(
+        self, config: QdrantConfig, mock_qdrant_wrapper: QdrantClientWrapper
+    ) -> None:
+        """SKIP strategy: BatchIngestionResult.skipped reflects skipped count."""
+        svc = IngestionService(
+            wrapper=mock_qdrant_wrapper,
+            config=config,
+            duplicate_strategy=DuplicateStrategy.SKIP,
+        )
+        setup = make_enriched_setup(trade_id="TRD-SKIP-COUNT")
+        embedding = make_embedding()
+
+        await svc.ingest_batch([(setup, embedding)])
+        result = await svc.ingest_batch([(setup, embedding)])
+
+        assert result.skipped == 1
+        assert result.successful == 0
+
+
+class TestConflictResolutionREFACTOR:
+    """
+    REFACTOR phase: conflict resolution strategy.
+    Requirements: FR-RAG-1
+    """
+
+    def test_duplicate_strategy_enum_has_upsert_and_skip(self) -> None:
+        """DuplicateStrategy enum must expose UPSERT and SKIP values."""
+        assert DuplicateStrategy.UPSERT is not None
+        assert DuplicateStrategy.SKIP is not None
+
+    def test_ingestion_service_exposes_seen_trade_ids(
+        self, config: QdrantConfig, mock_qdrant_wrapper: QdrantClientWrapper
+    ) -> None:
+        """IngestionService tracks seen trade_ids for in-session deduplication."""
+        svc = IngestionService(wrapper=mock_qdrant_wrapper, config=config)
+        assert hasattr(svc, "seen_trade_ids")
+        assert isinstance(svc.seen_trade_ids, set)
+
+    @pytest.mark.asyncio
+    async def test_seen_trade_ids_populated_after_ingest(
+        self, service: IngestionService
+    ) -> None:
+        """After ingestion, trade_ids are recorded in seen_trade_ids."""
+        setup = make_enriched_setup(trade_id="TRD-SEEN")
+        await service.ingest_batch([(setup, make_embedding())])
+
+        assert "TRD-SEEN" in service.seen_trade_ids
+
+    @pytest.mark.asyncio
+    async def test_clear_seen_trade_ids_resets_deduplication(
+        self, service: IngestionService, mock_qdrant_wrapper: QdrantClientWrapper
+    ) -> None:
+        """clear_seen_ids() resets the in-session deduplication cache."""
+        setup = make_enriched_setup(trade_id="TRD-CLEAR")
+        await service.ingest_batch([(setup, make_embedding())])
+
+        service.clear_seen_ids()
+
+        assert len(service.seen_trade_ids) == 0
+
+    @pytest.mark.asyncio
+    async def test_ingest_batch_with_mixed_new_and_duplicate_skip_strategy(
+        self, config: QdrantConfig, mock_qdrant_wrapper: QdrantClientWrapper
+    ) -> None:
+        """
+        SKIP strategy: a batch containing both new and already-seen trade_ids
+        must only forward the new ones to Qdrant.
+        """
+        svc = IngestionService(
+            wrapper=mock_qdrant_wrapper,
+            config=config,
+            duplicate_strategy=DuplicateStrategy.SKIP,
+        )
+        embedding = make_embedding()
+        # Pre-seed a known trade_id
+        await svc.ingest_batch([(make_enriched_setup(trade_id="TRD-OLD"), embedding)])
+        mock_qdrant_wrapper.upsert.reset_mock()
+
+        # Batch with 1 duplicate + 2 new
+        mixed_batch = [
+            (make_enriched_setup(trade_id="TRD-OLD"), embedding),
+            (make_enriched_setup(trade_id="TRD-NEW-1"), embedding),
+            (make_enriched_setup(trade_id="TRD-NEW-2"), embedding),
+        ]
+        result = await svc.ingest_batch(mixed_batch)
+
+        # Upsert is called once for the 2 new setups
+        assert mock_qdrant_wrapper.upsert.call_count == 1
+        points = mock_qdrant_wrapper.upsert.call_args.kwargs["points"]
+        assert len(points) == 2
+        assert result.successful == 2
+        assert result.skipped == 1
+
+
+# ---------------------------------------------------------------------------
+# build_point_from_setup() unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPointFromSetup:
+    """Unit tests for the pure helper function build_point_from_setup()."""
+
+    def test_returns_point_struct(self) -> None:
+        """build_point_from_setup() returns a qdrant PointStruct."""
+        point = build_point_from_setup(make_enriched_setup(), make_embedding())
+        assert isinstance(point, qmodels.PointStruct)
+
+    def test_vector_matches_embedding(self) -> None:
+        """The point vector equals the supplied embedding."""
+        embedding = make_embedding()
+        point = build_point_from_setup(make_enriched_setup(), embedding)
+        assert point.vector == embedding
+
+    def test_payload_instrument_is_uppercase(self) -> None:
+        """Instrument is normalised to uppercase regardless of input case."""
+        setup = make_enriched_setup(instrument="gbpusd")
+        point = build_point_from_setup(setup, make_embedding())
+        assert point.payload["instrument"] == "GBPUSD"
+
+    def test_payload_trade_id_preserved(self) -> None:
+        """trade_id is preserved exactly in the payload."""
+        setup = make_enriched_setup(trade_id="TRD-PRESERVE-001")
+        point = build_point_from_setup(setup, make_embedding())
+        assert point.payload["trade_id"] == "TRD-PRESERVE-001"
+
+    def test_payload_full_setup_equals_input(self) -> None:
+        """full_setup payload key contains a copy of the entire setup dict."""
+        setup = make_enriched_setup(trade_id="TRD-FULL-COPY")
+        point = build_point_from_setup(setup, make_embedding())
+        assert point.payload["full_setup"]["trade_id"] == "TRD-FULL-COPY"
+
+    def test_embedding_dimension_validated(self) -> None:
+        """build_point_from_setup() raises ValueError for wrong-dimension embeddings."""
+        with pytest.raises(ValueError, match="528"):
+            build_point_from_setup(make_enriched_setup(), [0.0] * 100)
+
+    def test_embedding_dim_constant_is_528(self) -> None:
+        """EMBEDDING_DIM module constant equals 528."""
+        assert EMBEDDING_DIM == 528
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (require live Qdrant)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestIngestionServiceIntegration:
+    """
+    Integration tests requiring a live Qdrant instance (localhost:6333).
+    Run with: pytest -m integration services/algorag/tests/test_ingestion_service.py
+    """
+
+    @pytest.mark.asyncio
+    async def test_ingest_and_count_live(self) -> None:
+        """Single setup can be ingested and counted in a live Qdrant collection."""
+        cfg = make_config(
+            host="localhost",
+            port=6333,
+            collection="test_ingestion_integration",
+            retry_backoff=0.1,
+        )
+        wrapper = QdrantClientWrapper(config=cfg)
+        svc = IngestionService(wrapper=wrapper, config=cfg)
+        try:
+            await wrapper.ensure_collection()
+            setup = make_enriched_setup(trade_id="TRD-LIVE-001")
+            result = await svc.ingest_batch([(setup, make_embedding())])
+
+            assert result.successful == 1
+            count = await wrapper.count()
+            assert count >= 1
+        finally:
+            await wrapper.delete_collection()
+            await wrapper.close()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_upsert_does_not_increase_count(self) -> None:
+        """Upserting the same trade_id twice does not create two records."""
+        cfg = make_config(
+            host="localhost",
+            port=6333,
+            collection="test_ingestion_dedup_integration",
+            retry_backoff=0.1,
+        )
+        wrapper = QdrantClientWrapper(config=cfg)
+        svc = IngestionService(wrapper=wrapper, config=cfg)
+        try:
+            await wrapper.ensure_collection()
+            setup = make_enriched_setup(trade_id="TRD-DEDUP-LIVE")
+            embedding = make_embedding()
+
+            await svc.ingest_batch([(setup, embedding)])
+            await svc.ingest_batch([(setup, embedding)])
+
+            count = await wrapper.count()
+            assert count == 1, f"Expected 1 point after double upsert, got {count}"
+        finally:
+            await wrapper.delete_collection()
+            await wrapper.close()


### PR DESCRIPTION
Task 6: Qdrant collection management
- Add QdrantClientWrapper with idempotent collection creation (528-dim cosine)
- Add ensure_indexes() for KEYWORD payload indexes on instrument, time_window, htf_open_bias, outcome_result
- Add validate_indexes() / rebuild_indexes() for operational runbooks
- Add delete_collection() for test teardown
- 44 tests covering schema, indexing, lifecycle, query performance

Task 7: Setup ingestion to vector store
- Add services/algorag/ingestion_service.py with IngestionService class
  - Batch upsert with configurable batch_size (default 100)
  - Deterministic point IDs via uuid5(NAMESPACE_DNS, trade_id) for Qdrant-native upsert deduplication (no duplicates on re-ingest)
  - DuplicateStrategy enum: UPSERT (default) and SKIP (in-session cache)
  - BatchIngestionResult dataclass: total/successful/failed/skipped counts plus ingested_ids list and per-batch error tuples for progress tracking
  - Eager 528-dim embedding validation before any network call
  - IngestionServiceError for catastrophic failures vs per-item errors
  - build_point_from_setup() pure helper function (instrument uppercased)
- Add 41 tests: batch ingestion, error handling, duplicate detection, conflict resolution, SKIP strategy, integration tests (gated)

All 133 AlgoRAG unit tests pass.
Requirements: FR-RAG-1, FR-RAG-7"