### PR TITLE
feat(ml): add OTE Fibonacci extractor and integrate into FeaturePipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,12 @@ checkpoints/
 docs/_build/
 site/
 
+# Reference PDFs and large binary documents (add manually, don't commit)
+docs/references/*.pdf
+docs/references/*.docx
+docs/references/*.pptx
+docs/references/*.xlsx
+
 # Trading data
 data/*.csv
 data/*.json

--- a/backend/tests/test_ote_extractor.py
+++ b/backend/tests/test_ote_extractor.py
@@ -1,0 +1,235 @@
+"""
+Test suite for OTE (Optimal Trade Entry) Fibonacci extractor.
+
+Validates TTrades OTE specification:
+  - Fibonacci levels: 0.5, 0.62, 0.705, 0.79
+  - OTE zone: 0.62–0.79 retracement
+  - Golden pocket: 0.705 level
+  - LONG: retracement from swing_high downward
+  - SHORT: retracement from swing_low upward
+
+Tests follow the same pattern as test_zone_features.py and test_htf_projections.py.
+
+**Validates: OTE feature extractor integration with FeaturePipeline**
+"""
+
+import os
+import sys
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+_WORKSPACE_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _WORKSPACE_ROOT not in sys.path:
+    sys.path.insert(0, _WORKSPACE_ROOT)
+
+from ml.features.ote_extractor import OTEExtractor, OTEFeatures  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SWING_HIGH = 1.5100
+SWING_LOW = 1.4900
+SWING_RANGE = SWING_HIGH - SWING_LOW  # 0.0200
+
+
+class TestOTEFeaturesDataclass:
+    """Test OTEFeatures dataclass structure."""
+
+    def test_ote_features_has_all_required_fields(self):
+        """OTEFeatures must expose all expected fields."""
+        f = OTEFeatures(
+            ote_in_zone=True,
+            ote_level_705=1.4959,
+            ote_level_62=1.4976,
+            ote_level_79=1.4942,
+            ote_distance_pct=0.0,
+            ote_valid=True,
+        )
+        assert hasattr(f, "ote_in_zone")
+        assert hasattr(f, "ote_level_705")
+        assert hasattr(f, "ote_level_62")
+        assert hasattr(f, "ote_level_79")
+        assert hasattr(f, "ote_distance_pct")
+        assert hasattr(f, "ote_valid")
+
+
+# ---------------------------------------------------------------------------
+# LONG direction tests
+# ---------------------------------------------------------------------------
+
+class TestOTELongDirection:
+    """Tests for LONG (bullish) OTE calculations."""
+
+    def setup_method(self):
+        self.extractor = OTEExtractor()
+
+    def test_ote_level_705_computed_correctly_for_long(self):
+        """0.705 level = swing_high - 0.705 * swing_range."""
+        expected = SWING_HIGH - 0.705 * SWING_RANGE  # 1.5100 - 0.0141 = 1.4959
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, 1.4959, "LONG")
+        assert features.ote_level_705 == pytest.approx(expected, abs=1e-6)
+
+    def test_ote_level_62_computed_correctly_for_long(self):
+        """0.62 level = swing_high - 0.62 * swing_range."""
+        expected = SWING_HIGH - 0.62 * SWING_RANGE   # 1.5100 - 0.0124 = 1.4976
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, 1.4976, "LONG")
+        assert features.ote_level_62 == pytest.approx(expected, abs=1e-6)
+
+    def test_ote_level_79_computed_correctly_for_long(self):
+        """0.79 level = swing_high - 0.79 * swing_range."""
+        expected = SWING_HIGH - 0.79 * SWING_RANGE   # 1.5100 - 0.0158 = 1.4942
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, 1.4942, "LONG")
+        assert features.ote_level_79 == pytest.approx(expected, abs=1e-6)
+
+    def test_in_zone_true_when_price_between_62_and_79_long(self):
+        """ote_in_zone must be True when price is inside the 0.62–0.79 zone."""
+        level_62 = SWING_HIGH - 0.62 * SWING_RANGE  # 1.4976
+        level_79 = SWING_HIGH - 0.79 * SWING_RANGE  # 1.4942
+        midpoint = (level_62 + level_79) / 2         # ~1.4959
+
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, midpoint, "LONG")
+        assert features.ote_in_zone is True
+
+    def test_in_zone_false_when_price_above_62_long(self):
+        """ote_in_zone must be False when price has not yet retraced to 0.62."""
+        price_above_62 = SWING_HIGH - 0.50 * SWING_RANGE  # only 50% retrace — not in zone
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, price_above_62, "LONG")
+        assert features.ote_in_zone is False
+
+    def test_in_zone_false_when_price_below_79_long(self):
+        """ote_in_zone must be False when price has overshot past 0.79."""
+        price_below_79 = SWING_HIGH - 0.90 * SWING_RANGE  # 90% retrace — beyond zone
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, price_below_79, "LONG")
+        assert features.ote_in_zone is False
+
+    def test_at_exact_62_boundary_is_in_zone_long(self):
+        """Price exactly at 0.62 level must be considered in zone (inclusive boundary)."""
+        level_62 = SWING_HIGH - 0.62 * SWING_RANGE
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, level_62, "LONG")
+        assert features.ote_in_zone is True
+
+    def test_at_exact_79_boundary_is_in_zone_long(self):
+        """Price exactly at 0.79 level must be considered in zone (inclusive boundary)."""
+        level_79 = SWING_HIGH - 0.79 * SWING_RANGE
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, level_79, "LONG")
+        assert features.ote_in_zone is True
+
+    def test_ote_valid_true_for_valid_inputs_long(self):
+        """ote_valid must be True when swing_high > swing_low."""
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, 1.4959, "LONG")
+        assert features.ote_valid is True
+
+    def test_distance_pct_zero_when_at_705_level_long(self):
+        """ote_distance_pct should be ~0 when current price equals the 0.705 level."""
+        level_705 = SWING_HIGH - 0.705 * SWING_RANGE
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, level_705, "LONG")
+        assert features.ote_distance_pct == pytest.approx(0.0, abs=1e-4)
+
+    def test_distance_pct_positive_when_above_705_long(self):
+        """ote_distance_pct should be positive when price is above 0.705 (not yet retraced)."""
+        above_705 = SWING_HIGH - 0.62 * SWING_RANGE  # 0.62 level > 0.705 level for LONG
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, above_705, "LONG")
+        assert features.ote_distance_pct > 0.0
+
+
+# ---------------------------------------------------------------------------
+# SHORT direction tests
+# ---------------------------------------------------------------------------
+
+class TestOTEShortDirection:
+    """Tests for SHORT (bearish) OTE calculations."""
+
+    def setup_method(self):
+        self.extractor = OTEExtractor()
+
+    def test_ote_level_705_computed_correctly_for_short(self):
+        """0.705 level = swing_low + 0.705 * swing_range."""
+        expected = SWING_LOW + 0.705 * SWING_RANGE   # 1.4900 + 0.0141 = 1.5041
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, 1.5041, "SHORT")
+        assert features.ote_level_705 == pytest.approx(expected, abs=1e-6)
+
+    def test_ote_level_62_computed_correctly_for_short(self):
+        """0.62 level = swing_low + 0.62 * swing_range."""
+        expected = SWING_LOW + 0.62 * SWING_RANGE    # 1.4900 + 0.0124 = 1.5024
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, 1.5024, "SHORT")
+        assert features.ote_level_62 == pytest.approx(expected, abs=1e-6)
+
+    def test_in_zone_true_when_price_between_62_and_79_short(self):
+        """ote_in_zone must be True when price retraced into 0.62–0.79 zone (SHORT)."""
+        level_62 = SWING_LOW + 0.62 * SWING_RANGE   # 1.5024
+        level_79 = SWING_LOW + 0.79 * SWING_RANGE   # 1.5058
+        midpoint = (level_62 + level_79) / 2          # ~1.5041
+
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, midpoint, "SHORT")
+        assert features.ote_in_zone is True
+
+    def test_in_zone_false_when_price_below_62_short(self):
+        """ote_in_zone must be False when price has not yet retraced to 0.62 (SHORT)."""
+        price_below_62 = SWING_LOW + 0.50 * SWING_RANGE  # 50% retrace — not in zone
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, price_below_62, "SHORT")
+        assert features.ote_in_zone is False
+
+    def test_in_zone_false_when_price_above_79_short(self):
+        """ote_in_zone must be False when price overshot past 0.79 (SHORT)."""
+        price_above_79 = SWING_LOW + 0.90 * SWING_RANGE  # 90% retrace — beyond zone
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, price_above_79, "SHORT")
+        assert features.ote_in_zone is False
+
+
+# ---------------------------------------------------------------------------
+# Edge cases and degenerate inputs
+# ---------------------------------------------------------------------------
+
+class TestOTEEdgeCases:
+    """Tests for edge cases and degenerate inputs."""
+
+    def setup_method(self):
+        self.extractor = OTEExtractor()
+
+    def test_degenerate_swing_high_equals_low_returns_valid_false(self):
+        """When swing_high == swing_low, ote_valid must be False."""
+        features = self.extractor.extract(1.5000, 1.5000, 1.5000, "LONG")
+        assert features.ote_valid is False
+        assert features.ote_in_zone is False
+
+    def test_degenerate_swing_range_zero_returns_current_price_as_levels(self):
+        """When swing range is zero, all levels should equal current price."""
+        price = 1.5000
+        features = self.extractor.extract(1.5000, 1.5000, price, "LONG")
+        assert features.ote_level_705 == price
+        assert features.ote_level_62 == price
+        assert features.ote_level_79 == price
+
+    def test_swing_high_below_swing_low_returns_valid_false(self):
+        """When swing_high < swing_low (invalid), ote_valid must be False."""
+        features = self.extractor.extract(1.4900, 1.5100, 1.5000, "LONG")
+        assert features.ote_valid is False
+
+    def test_default_direction_long_works(self):
+        """Calling extract without direction should default to LONG."""
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, 1.4959)
+        assert features.ote_valid is True
+        # LONG 0.705 level
+        expected = SWING_HIGH - 0.705 * SWING_RANGE
+        assert features.ote_level_705 == pytest.approx(expected, abs=1e-6)
+
+    def test_price_at_swing_high_not_in_zone_long(self):
+        """Price at swing high (0% retrace) should not be in OTE zone."""
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, SWING_HIGH, "LONG")
+        assert features.ote_in_zone is False
+
+    def test_price_at_swing_low_not_in_zone_long(self):
+        """Price at swing low (100% retrace) should not be in OTE zone."""
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, SWING_LOW, "LONG")
+        assert features.ote_in_zone is False
+
+    def test_ote_distance_pct_range(self):
+        """ote_distance_pct should be a finite float for valid inputs."""
+        features = self.extractor.extract(SWING_HIGH, SWING_LOW, 1.4960, "LONG")
+        assert isinstance(features.ote_distance_pct, float)
+        assert abs(features.ote_distance_pct) < 1000.0  # sanity: not absurdly large

--- a/docs/references/README.md
+++ b/docs/references/README.md
@@ -1,0 +1,48 @@
+# Reference Materials
+
+This folder contains source educational materials and frameworks that inform the
+AgentICTrader platform design, methodology, and implementation.
+
+## Contents
+
+Place your reference PDFs and documents here. Suggested naming convention:
+
+```
+ttrades_<topic>.pdf          — Ttrades educational template materials
+ict_<topic>.pdf              — ICT (Inner Circle Trader) methodology resources
+<source>_<topic>.<ext>       — Any other reference materials
+```
+
+## How These Are Used
+
+Once documents are added here, they can be:
+
+1. **Dragged into a Kiro chat session** to directly compare against the current
+   implementation and identify gaps or misalignments.
+
+2. **Used to improve the ML labellers** — particularly:
+   - `ml/models/pattern_detector/labeller.py` — pattern detection rules
+   - `ml/models/confluence_scorer/train.py` — confluence scoring heuristics
+
+3. **Used to validate ICT terminology and logic** against what is encoded in:
+   - `ml/features/zone_features.py` — Premium/Discount/PD Array detection
+   - `ml/features/session_features.py` — Killzone and Silver Bullet windows
+   - `ml/features/htf_projections.py` — HTF candle projection logic
+   - `backend/trader/agents/pd_array/` — PD Array agents
+   - `backend/trader/agents/cisd.py` — CISD logic
+
+4. **Used as a source of ground truth** for backtesting setups and seeding the
+   RAG pipeline (Qdrant collection) with historically validated trade examples.
+
+## Priority Areas for Gap Analysis
+
+When reviewing the Ttrades materials against this codebase, focus on:
+
+| Area | Current Implementation | What to Check |
+|---|---|---|
+| Entry criteria | Heuristic labeller (score ≥ 3.5) | Does Ttrades define specific entry rules? |
+| Trade management | Partial close at 1R, SL to BE | Does Ttrades use a different R management framework? |
+| Killzone definitions | London, NY AM, NY PM, Silver Bullets | Are Ttrades session windows identical? |
+| PD Array hierarchy | OB > FVG > Breaker > IFVG | Does Ttrades rank arrays differently? |
+| Confluence criteria | 5 signals scored | Does Ttrades have a specific confluence checklist? |
+| Liquidity concepts | Sweep detection only | Does Ttrades cover inducement or turtle soup patterns? |

--- a/ml/features/ote_extractor.py
+++ b/ml/features/ote_extractor.py
@@ -1,0 +1,160 @@
+"""ml/features/ote_extractor.py — Optimal Trade Entry (OTE) feature extractor.
+
+Computes Fibonacci-based OTE levels from swing high/low anchor points.
+
+TTrades OTE specification:
+  - Fibonacci levels: 0, 0.5, 0.62, 0.705, 0.79, 1
+  - Anchor: swing high → swing low (bearish) or swing low → swing high (bullish)
+  - OTE zone: 0.62–0.79 retracement
+  - Golden pocket (optimal entry): 0.705 level
+  - Valid OTE: price is currently inside [0.62, 0.79] retracement zone
+
+The OTE extractor is stateless — no fit() required.
+Follows the same @dataclass + class pattern as ZoneFeatureExtractor and HTFProjectionExtractor.
+
+Integration:
+  - Called from FeaturePipeline.transform() after ZoneFeatureExtractor
+  - Swing high/low come from ZoneFeatureExtractor._find_last_swing_high/low()
+  - OTE features feed the confluence scorer as additional confluence signals
+  - When ote_in_zone=True, InferenceEngine uses ote_level_705 as entry price
+
+Example usage:
+    >>> from ml.features.ote_extractor import OTEExtractor
+    >>> extractor = OTEExtractor()
+    >>> # Bullish setup: price retraced from swing low to swing high, now pulling back
+    >>> features = extractor.extract(
+    ...     swing_high=1.5100,
+    ...     swing_low=1.4900,
+    ...     current_price=1.5041,   # ~70.5% retracement into zone
+    ...     direction="LONG",
+    ... )
+    >>> features.ote_in_zone
+    True
+    >>> round(features.ote_level_705, 4)
+    1.4959  # for a SHORT; for LONG: 1.5100 - 0.705 * (1.5100 - 1.4900) = 1.4959... 
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# OTE Fibonacci constants (TTrades specification)
+# ---------------------------------------------------------------------------
+_FIB_0_5 = 0.5
+_FIB_0_62 = 0.62
+_FIB_0_705 = 0.705   # Golden pocket — primary entry level
+_FIB_0_79 = 0.79
+
+
+@dataclass
+class OTEFeatures:
+    """OTE (Optimal Trade Entry) features derived from Fibonacci retracement.
+
+    Attributes:
+        ote_in_zone: True when current price is inside the 0.62–0.79 OTE zone.
+        ote_level_705: The 0.705 golden pocket price level for the current swing.
+        ote_level_62: The 0.62 Fibonacci level price.
+        ote_level_79: The 0.79 Fibonacci level price.
+        ote_distance_pct: Distance of current price from the 0.705 level,
+            expressed as a percentage of the swing range. 0.0 when at the
+            golden pocket exactly. Negative when below 0.705 (for LONG),
+            positive when above.
+        ote_valid: True when a valid swing exists (swing_high > swing_low)
+            and direction is provided. False when inputs are degenerate.
+    """
+
+    ote_in_zone: bool
+    ote_level_705: float
+    ote_level_62: float
+    ote_level_79: float
+    ote_distance_pct: float
+    ote_valid: bool
+
+
+class OTEExtractor:
+    """Optimal Trade Entry (OTE) Fibonacci extractor.
+
+    Computes OTE levels and determines whether current price is inside the
+    0.62–0.79 retracement zone relative to the most recent swing.
+
+    For a LONG setup:
+        - Swing move: swing_low → swing_high (price ran up)
+        - Retracement: price pulls back toward swing_low
+        - OTE zone: 0.62–0.79 retracement FROM swing_high BACK TOWARD swing_low
+        - Level formula: swing_high - fib * (swing_high - swing_low)
+
+    For a SHORT setup:
+        - Swing move: swing_high → swing_low (price ran down)
+        - Retracement: price retraces toward swing_high
+        - OTE zone: 0.62–0.79 retracement FROM swing_low BACK TOWARD swing_high
+        - Level formula: swing_low + fib * (swing_high - swing_low)
+    """
+
+    def extract(
+        self,
+        swing_high: float,
+        swing_low: float,
+        current_price: float,
+        direction: str = "LONG",
+    ) -> OTEFeatures:
+        """Compute OTE features for the current price relative to the swing.
+
+        Args:
+            swing_high: Most recent swing high price.
+            swing_low: Most recent swing low price.
+            current_price: Current market price (latest candle close).
+            direction: Trade direction — "LONG" or "SHORT". Determines which
+                       end of the swing the Fibonacci anchors from.
+
+        Returns:
+            OTEFeatures with zone status, price levels, and distance metrics.
+        """
+        swing_range = swing_high - swing_low
+
+        # Degenerate input guard
+        if swing_range <= 0 or not direction:
+            return OTEFeatures(
+                ote_in_zone=False,
+                ote_level_705=current_price,
+                ote_level_62=current_price,
+                ote_level_79=current_price,
+                ote_distance_pct=0.0,
+                ote_valid=False,
+            )
+
+        if direction == "LONG":
+            # Retracement levels measured downward from swing_high
+            level_62 = swing_high - _FIB_0_62 * swing_range
+            level_705 = swing_high - _FIB_0_705 * swing_range
+            level_79 = swing_high - _FIB_0_79 * swing_range
+
+            # Price is in OTE zone when it has pulled back into [level_79, level_62]
+            # (level_79 < level_62 since we subtract more for 0.79)
+            in_zone = level_79 <= current_price <= level_62
+
+            # Distance from golden pocket: positive means price is above 0.705 (not yet there)
+            distance_pct = ((current_price - level_705) / swing_range) * 100.0
+
+        else:  # SHORT
+            # Retracement levels measured upward from swing_low
+            level_62 = swing_low + _FIB_0_62 * swing_range
+            level_705 = swing_low + _FIB_0_705 * swing_range
+            level_79 = swing_low + _FIB_0_79 * swing_range
+
+            # Price is in OTE zone when it has retraced into [level_62, level_79]
+            # (level_62 < level_79 since we add more for 0.79)
+            in_zone = level_62 <= current_price <= level_79
+
+            # Distance from golden pocket: negative means price is below 0.705 (not yet there)
+            distance_pct = ((current_price - level_705) / swing_range) * 100.0
+
+        return OTEFeatures(
+            ote_in_zone=in_zone,
+            ote_level_705=level_705,
+            ote_level_62=level_62,
+            ote_level_79=level_79,
+            ote_distance_pct=distance_pct,
+            ote_valid=True,
+        )

--- a/ml/features/pipeline.py
+++ b/ml/features/pipeline.py
@@ -46,6 +46,7 @@ from ml.features.htf_projections import HTFProjectionExtractor
 from ml.features.candle_features import CandleFeatureExtractor
 from ml.features.zone_features import ZoneFeatureExtractor
 from ml.features.session_features import TimeWindowClassifier
+from ml.features.ote_extractor import OTEExtractor
 
 
 class DataQualityError(Exception):
@@ -113,6 +114,7 @@ class FeaturePipeline:
         self.candle_extractor = CandleFeatureExtractor()
         self.zone_extractor = ZoneFeatureExtractor()
         self.session_classifier = TimeWindowClassifier()
+        self.ote_extractor = OTEExtractor()
         self.enable_validation = enable_validation
     
     def fit(self, **kwargs):
@@ -141,6 +143,7 @@ class FeaturePipeline:
         true_day_open: Optional[float] = None,
         sentiment_score: float = 0.0,
         blackout_active: bool = False,
+        direction: Optional[str] = None,
     ) -> pd.DataFrame:
         """
         Transform candle data into a flat feature vector.
@@ -160,6 +163,8 @@ class FeaturePipeline:
             blackout_active: Whether a HIGH-impact economic event is within ±15 min.
                             Sourced from Redis key ``blackout:{instrument}`` (TTL 120s).
                             Defaults to False when not provided.
+            direction: Trade direction — "LONG" or "SHORT". If None, derived
+                       automatically from htf_open_bias (BULLISH → LONG, BEARISH → SHORT).
             
         Returns:
             pandas DataFrame with one row and named feature columns
@@ -238,6 +243,31 @@ class FeaturePipeline:
         feature_dict["sentiment_score"] = float(sentiment_score)
         feature_dict["blackout_active"] = bool(blackout_active)
         
+        # Add OTE (Optimal Trade Entry) Fibonacci features
+        # Derive direction from htf_open_bias if not explicitly provided
+        ote_direction = direction
+        if ote_direction is None:
+            bias = feature_dict.get("htf_open_bias", "NEUTRAL")
+            ote_direction = "LONG" if bias == "BULLISH" else "SHORT" if bias == "BEARISH" else "LONG"
+        
+        swing_high = zone_features.swing_high_distance + current_price
+        swing_low = current_price - zone_features.swing_low_distance
+        
+        ote_features = self.ote_extractor.extract(
+            swing_high=swing_high,
+            swing_low=swing_low,
+            current_price=current_price,
+            direction=ote_direction,
+        )
+        feature_dict.update({
+            "ote_in_zone": ote_features.ote_in_zone,
+            "ote_level_705": ote_features.ote_level_705,
+            "ote_level_62": ote_features.ote_level_62,
+            "ote_level_79": ote_features.ote_level_79,
+            "ote_distance_pct": ote_features.ote_distance_pct,
+            "ote_valid": ote_features.ote_valid,
+        })
+        
         # Convert to DataFrame (single row)
         df = pd.DataFrame([feature_dict])
         
@@ -258,6 +288,7 @@ class FeaturePipeline:
         true_day_open: Optional[float] = None,
         sentiment_score: float = 0.0,
         blackout_active: bool = False,
+        direction: Optional[str] = None,
     ) -> pd.DataFrame:
         """
         Fit and transform in one step (equivalent to transform for stateless pipeline).
@@ -289,6 +320,7 @@ class FeaturePipeline:
             true_day_open=true_day_open,
             sentiment_score=sentiment_score,
             blackout_active=blackout_active,
+            direction=direction,
         )
     
     def get_feature_names(self) -> List[str]:


### PR DESCRIPTION
Implements TTrades Optimal Trade Entry (OTE) specification:
- OTE zone: 0.62–0.79 Fibonacci retracement of swing high/low
- Golden pocket: 0.705 level (primary entry level)
- Supports LONG (retracement downward from swing high) and SHORT (retracement upward from swing low) directions

New files:
- ml/features/ote_extractor.py: OTEExtractor class + OTEFeatures dataclass following the same stateless @dataclass+class pattern as existing extractors
- backend/tests/test_ote_extractor.py: 24 tests covering LONG levels, SHORT levels, zone boundaries, edge cases, degenerate inputs (all passing)

Modified files:
- ml/features/pipeline.py: OTEExtractor integrated into FeaturePipeline.transform() Direction auto-derived from htf_open_bias (BULLISH→LONG, BEARISH→SHORT) New features added to vector: ote_in_zone, ote_level_705, ote_level_62, ote_level_79, ote_distance_pct, ote_valid
- .gitignore: exclude PDFs and binary docs from docs/references/
- docs/references/README.md: TTrades reference materials index with gap analysis

Test results: 79 passed, 2 skipped (TimescaleDB), 0 failures